### PR TITLE
feat(executor): guard reserved kwargs and enforce keywords-only enqueue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ test/internal/db/*.sqlite*
 ai_tools
 .DS_Store
 Gemfile.lock
+# git worktrees
+.worktrees/

--- a/docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md
+++ b/docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md
@@ -1,0 +1,241 @@
+# Reserved-keyword Guard + Keywords-only Enqueue Contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the public `perform_now`/`perform_later` of `Executor`-prepended jobs reject ChronoForge's reserved internal kwargs and any extra positional argument, while keeping `options`/user kwargs and the `retry_now`/`retry_later` helpers working.
+
+**Architecture:** All changes live in `lib/chrono_forge/executor.rb` inside the `class << base` block (plus one module-level constant). A shared private `__validate_enqueue!` guard backs both public enqueue methods. `retry_now`/`retry_later` are rewritten to enqueue through `.set(...)`, whose ActiveJob `ConfiguredJob` proxy bypasses the class-level override, letting the framework inject the reserved `retry_workflow: true` flag past the guard. Framework continuations already use `.set(...)` and need no change.
+
+**Tech Stack:** Ruby, Rails/ActiveJob 7.1.3.4, Minitest (`ActiveJob::TestCase`), ChaoticJob test helpers, Combustion test harness.
+
+**User Verification:** NO — no user verification required.
+
+---
+
+## File Structure
+
+- **Modify** `lib/chrono_forge/executor.rb`
+  - Add module-level constant `RESERVED_KWARGS` near `STEP_NAME_DELIMITER` (line 19).
+  - Replace the `perform_now`, `perform_later`, `retry_now`, `retry_later` definitions in the `class << base` block (lines ~29–54). Leave `retry_policy` (lines ~56–68) untouched.
+  - Append a `private` section with `__validate_enqueue!` at the **end** of the `class << base` block (after `retry_policy`) so `retry_policy` stays public.
+- **Create** `test/enqueue_contract_test.rb` — covers reserved-key rejection, keywords-only contract, non-string key, `options`/kwargs pass-through, and retry-helper reserved-key rejection.
+
+---
+
+### Task 1: Reserved-key + keywords-only enqueue guard, with retry-helper rerouting
+
+**Goal:** Public `perform_now`/`perform_later` reject `attempt`/`retry_counts`/`retry_workflow` and extra positionals; `options` and user kwargs still flow through; `retry_now`/`retry_later` keep working by routing past the guard.
+
+**Files:**
+- Modify: `lib/chrono_forge/executor.rb` (constant near line 19; `class << base` block lines ~29–54; append private helper before the block's closing `end` at line ~69)
+- Test: `test/enqueue_contract_test.rb` (create)
+
+**Acceptance Criteria:**
+- [ ] `perform_later`/`perform_now` raise `ArgumentError` (message names the key, contains "reserved") when passed `attempt:`, `retry_counts:`, or `retry_workflow:`, and enqueue nothing.
+- [ ] `perform_later`/`perform_now` raise `ArgumentError` (message mentions "keyword") when given a second positional argument.
+- [ ] Non-String `key` still raises `ArgumentError`.
+- [ ] `perform_later(key, foo:, options:)` enqueues; `options` reaches `workflow.options` and user kwargs reach `workflow.kwargs`/the job body.
+- [ ] `retry_now`/`retry_later` reject reserved keys supplied by the caller, and the existing retry end-to-end tests still pass.
+- [ ] Full suite green: `bundle exec rake test`.
+
+**Verify:** `bundle exec rake test TEST=test/enqueue_contract_test.rb` → all pass, then `bundle exec rake test` → 139+ tests, 0 failures, 0 errors.
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/enqueue_contract_test.rb`:
+
+```ruby
+require "test_helper"
+
+# Public enqueue contract for Executor-prepended jobs: perform_now/perform_later
+# accept exactly one positional (`key`) plus keywords, reject ChronoForge's
+# reserved internal kwargs, and pass `options`/user kwargs through to the
+# workflow record. retry_now/retry_later route past the guard via `.set(...)`.
+class EnqueueContractTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  RESERVED = %i[attempt retry_counts retry_workflow].freeze
+
+  def setup
+    ChronoForge::Workflow.destroy_all
+  end
+
+  class ContractJob < WorkflowJob
+    prepend ChronoForge::Executor
+    def perform(foo: nil)
+      context[:foo] = foo
+    end
+  end
+
+  # --- reserved-key rejection ------------------------------------------------
+
+  def test_perform_later_rejects_reserved_keys
+    RESERVED.each do |reserved|
+      err = assert_raises(ArgumentError) do
+        assert_no_enqueued_jobs do
+          ContractJob.perform_later("k-#{reserved}", reserved => 1)
+        end
+      end
+      assert_match(/reserved/, err.message)
+      assert_match(reserved.to_s, err.message)
+    end
+  end
+
+  def test_perform_now_rejects_reserved_keys
+    RESERVED.each do |reserved|
+      err = assert_raises(ArgumentError) do
+        ContractJob.perform_now("k-#{reserved}", reserved => 1)
+      end
+      assert_match(/reserved/, err.message)
+    end
+  end
+
+  # --- keywords-only contract ------------------------------------------------
+
+  def test_perform_later_rejects_extra_positional
+    err = assert_raises(ArgumentError) do
+      assert_no_enqueued_jobs { ContractJob.perform_later("k", 99) }
+    end
+    assert_match(/keyword/, err.message)
+  end
+
+  def test_perform_now_rejects_extra_positional
+    err = assert_raises(ArgumentError) { ContractJob.perform_now("k", 99) }
+    assert_match(/keyword/, err.message)
+  end
+
+  def test_non_string_key_still_rejected
+    assert_raises(ArgumentError) { ContractJob.perform_later(123) }
+    assert_raises(ArgumentError) { ContractJob.perform_now(123) }
+  end
+
+  # --- public kwargs pass through --------------------------------------------
+
+  def test_options_and_user_kwargs_pass_through
+    key = "contract-#{SecureRandom.hex(4)}"
+    ContractJob.perform_later(key, foo: "bar", options: {plan: "pro"})
+    perform_all_jobs
+
+    wf = ChronoForge::Workflow.find_by(key: key)
+    assert_equal({"plan" => "pro"}, wf.options)
+    assert_equal "bar", wf.kwargs["foo"]
+    assert_equal "bar", wf.context["foo"]
+  end
+
+  # --- retry helpers route past the guard ------------------------------------
+
+  def test_retry_helpers_reject_reserved_keys_from_caller
+    assert_raises(ArgumentError) { ContractJob.retry_now("k", attempt: 1) }
+    assert_raises(ArgumentError) { ContractJob.retry_later("k", attempt: 1) }
+  end
+end
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `bundle exec rake test TEST=test/enqueue_contract_test.rb`
+Expected: FAIL — reserved-key/positional rejection tests fail because the current guard only checks `key.is_a?(String)` (reserved kwargs are silently swallowed; a second positional raises Ruby's generic arity error, not our message — so the `/keyword/` match fails).
+
+- [ ] **Step 3: Add the `RESERVED_KWARGS` constant**
+
+In `lib/chrono_forge/executor.rb`, after the `STEP_NAME_DELIMITER` definition (line 19), add:
+
+```ruby
+    # Keyword args ChronoForge threads through job args internally. Users must
+    # not pass these to perform_now/perform_later; the framework injects them
+    # via `.set(...)` continuations, whose ConfiguredJob proxy bypasses the
+    # class-level guard in `prepended` below.
+    RESERVED_KWARGS = %i[attempt retry_counts retry_workflow].freeze
+```
+
+- [ ] **Step 4: Rewrite the enqueue/retry methods**
+
+In the `class << base` block, replace the existing `perform_now`, `perform_later`, `retry_now`, and `retry_later` definitions (lines ~29–54) with:
+
+```ruby
+        # Public enqueue contract: exactly one positional (`key`) plus keywords.
+        # Reserved internal kwargs (RESERVED_KWARGS) are rejected here; the
+        # framework injects them only via `.set(...)` continuations, whose
+        # ActiveJob ConfiguredJob proxy bypasses these class-level overrides.
+        def perform_now(key, *extra, **kwargs)
+          __validate_enqueue!(key, extra, kwargs)
+          super(key, **kwargs)
+        end
+
+        def perform_later(key, *extra, **kwargs)
+          __validate_enqueue!(key, extra, kwargs)
+          super(key, **kwargs)
+        end
+
+        # Re-run a failed/stalled workflow. Routes through `.set(...)` so the
+        # reserved `retry_workflow: true` flag reaches the instance perform
+        # without tripping the public guard above.
+        def retry_now(key, **kwargs)
+          __validate_enqueue!(key, [], kwargs)
+          set.perform_now(key, retry_workflow: true, **kwargs)
+        end
+
+        def retry_later(key, **kwargs)
+          __validate_enqueue!(key, [], kwargs)
+          set.perform_later(key, retry_workflow: true, **kwargs)
+        end
+```
+
+Leave the `retry_policy` method that follows **unchanged**.
+
+- [ ] **Step 5: Append the private guard at the end of the `class << base` block**
+
+Immediately before the `end` that closes `class << base` (after `retry_policy`, line ~69), add:
+
+```ruby
+
+        private
+
+        def __validate_enqueue!(key, extra, kwargs)
+          unless key.is_a?(String)
+            raise ArgumentError, "Workflow key must be a string as the first argument"
+          end
+          unless extra.empty?
+            raise ArgumentError,
+              "ChronoForge workflows accept only `key` positionally; pass " \
+              "everything else as keywords (got #{extra.size} extra positional arg(s))"
+          end
+          reserved = kwargs.keys & RESERVED_KWARGS
+          if reserved.any?
+            raise ArgumentError,
+              "#{reserved.join(", ")} #{reserved.one? ? "is a reserved" : "are reserved"} " \
+              "ChronoForge keyword(s) and cannot be passed to perform_now/perform_later"
+          end
+        end
+```
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `bundle exec rake test TEST=test/enqueue_contract_test.rb`
+Expected: PASS (all tests).
+
+- [ ] **Step 7: Run the full suite (regression — confirms retry rewrite is safe)**
+
+Run: `bundle exec rake test`
+Expected: PASS — 139 prior tests + new file, 0 failures, 0 errors. This is the safety net for the `retry_now`/`retry_later` rewrite (existing retry e2e tests in `test/workflow_retry_api_test.rb` and `test/chrono_forge_test.rb` exercise the happy path).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add lib/chrono_forge/executor.rb test/enqueue_contract_test.rb docs/superpowers/specs/2026-06-25-reserved-kwarg-guard-design.md docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md
+git commit -m "feat(executor): guard reserved kwargs and enforce keywords-only enqueue"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/executor.rb", "test/enqueue_contract_test.rb"], "verifyCommand": "bundle exec rake test", "acceptanceCriteria": ["perform_now/perform_later reject attempt/retry_counts/retry_workflow with a clear ArgumentError and enqueue nothing", "extra positional args rejected with a keywords-only message", "non-string key still rejected", "options and user kwargs pass through to the workflow record", "retry_now/retry_later reject caller-supplied reserved keys and existing retry e2e tests still pass", "full suite green"], "requiresUserVerification": false}
+```
+
+---
+
+## Notes / Out of Scope
+
+- `wait_condition` (internal kwarg in `wait_until`) is intentionally **not** added to `RESERVED_KWARGS`: it only travels via `.set(...)` and never reaches the guard.
+- `ChronoForge::CleanupJob` is a plain `ActiveJob::Base` (does not prepend `Executor`); the guard does not apply to it.
+- The gemspec leaves `activerecord` unpinned; a fresh `bundle install` can resolve to Rails 8.1 and conflict with `sqlite3 ~> 1.4`. Unrelated to this change — keep the worktree on main's known-good `Gemfile.lock` (Rails 7.1.3.4).

--- a/docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md.tasks.json
@@ -4,7 +4,7 @@
     {
       "id": 1,
       "subject": "Task 1: Reserved-key + keywords-only enqueue guard with retry-helper rerouting",
-      "status": "pending",
+      "status": "completed",
       "description": "**Goal:** Public perform_now/perform_later of Executor-prepended jobs reject attempt/retry_counts/retry_workflow and extra positionals; options and user kwargs still flow through; retry_now/retry_later keep working by routing past the guard via `.set(...)`.\n\n**Files:**\n- Modify: `lib/chrono_forge/executor.rb` (RESERVED_KWARGS constant near line 19; rewrite perform_now/perform_later/retry_now/retry_later in `class << base` ~29-54; append private `__validate_enqueue!` at end of block after retry_policy)\n- Test: `test/enqueue_contract_test.rb` (create)\n\n**Verify:** `bundle exec rake test TEST=test/enqueue_contract_test.rb` then `bundle exec rake test`\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/executor.rb\", \"test/enqueue_contract_test.rb\"], \"verifyCommand\": \"bundle exec rake test\", \"acceptanceCriteria\": [\"perform_now/perform_later reject attempt/retry_counts/retry_workflow with a clear ArgumentError and enqueue nothing\", \"extra positional args rejected with a keywords-only message\", \"non-string key still rejected\", \"options and user kwargs pass through to the workflow record\", \"retry_now/retry_later reject caller-supplied reserved keys and existing retry e2e tests still pass\", \"full suite green\"], \"requiresUserVerification\": false}\n```"
     }
   ],

--- a/docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md.tasks.json
@@ -1,0 +1,12 @@
+{
+  "planPath": "docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "Task 1: Reserved-key + keywords-only enqueue guard with retry-helper rerouting",
+      "status": "pending",
+      "description": "**Goal:** Public perform_now/perform_later of Executor-prepended jobs reject attempt/retry_counts/retry_workflow and extra positionals; options and user kwargs still flow through; retry_now/retry_later keep working by routing past the guard via `.set(...)`.\n\n**Files:**\n- Modify: `lib/chrono_forge/executor.rb` (RESERVED_KWARGS constant near line 19; rewrite perform_now/perform_later/retry_now/retry_later in `class << base` ~29-54; append private `__validate_enqueue!` at end of block after retry_policy)\n- Test: `test/enqueue_contract_test.rb` (create)\n\n**Verify:** `bundle exec rake test TEST=test/enqueue_contract_test.rb` then `bundle exec rake test`\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/executor.rb\", \"test/enqueue_contract_test.rb\"], \"verifyCommand\": \"bundle exec rake test\", \"acceptanceCriteria\": [\"perform_now/perform_later reject attempt/retry_counts/retry_workflow with a clear ArgumentError and enqueue nothing\", \"extra positional args rejected with a keywords-only message\", \"non-string key still rejected\", \"options and user kwargs pass through to the workflow record\", \"retry_now/retry_later reject caller-supplied reserved keys and existing retry e2e tests still pass\", \"full suite green\"], \"requiresUserVerification\": false}\n```"
+    }
+  ],
+  "lastUpdated": "2026-06-25T00:00:00Z"
+}

--- a/docs/superpowers/specs/2026-06-25-reserved-kwarg-guard-design.md
+++ b/docs/superpowers/specs/2026-06-25-reserved-kwarg-guard-design.md
@@ -1,0 +1,169 @@
+# Reserved-keyword guard + keywords-only enqueue contract
+
+Date: 2026-06-25
+Status: Approved (design)
+
+## Problem
+
+`ChronoForge::Executor#perform` reserves several keyword parameters for internal
+plumbing:
+
+```ruby
+def perform(key, attempt: 0, retry_counts: {}, retry_workflow: false, options: {}, **kwargs)
+```
+
+Anything not named here lands in `**kwargs`, is persisted on the `Workflow` row,
+and is replayed to the user's job body via `super(**workflow.kwargs.symbolize_keys)`
+(`executor.rb:100`).
+
+Two problems follow from the current public enqueue surface
+(`perform_now`/`perform_later`), which only validate that `key` is a String:
+
+1. **Silent collision.** A user calling `MyJob.perform_later("k", attempt: 5)`
+   silently hijacks the internal retry counter instead of passing their own
+   argument. Same risk for `retry_counts` and `retry_workflow`.
+2. **No positional contract.** Extra positional arguments produce Ruby's generic
+   `wrong number of arguments` error rather than a contract-specific message —
+   even though the executor only ever replays kwargs (keyword-only) to the job
+   body, so positionals beyond `key` can never work.
+
+## Decisions (settled with maintainer)
+
+- **Public keyword surface:** `key` (required, first positional), `options`
+  (free-form metadata bag), and user `**kwargs`. Nothing else.
+- **`options` is unstructured.** The framework defines **zero** recognized option
+  keys. `options` is written to `workflow.options` (`executor.rb:159`) and only
+  ever read back by callers (`workflow.options`); no key in it drives behavior.
+- **Reserved keys (rejected on the public path):** `attempt`, `retry_counts`,
+  `retry_workflow`. These are internal threading params; users have no legitimate
+  reason to pass them.
+- **`retry_workflow` is internal**, reached only through the `retry_now` /
+  `retry_later` helpers — not by passing the flag directly.
+- **Keywords-only:** exactly one positional (`key`); everything else must be a
+  keyword, enforced with a clear, contract-specific error.
+- **No job-signature validation.** We do *not* introspect the job's `perform`
+  parameters to validate unknown/missing kwargs. Out of scope; mismatches still
+  surface at execution time as today.
+
+## Mechanism: how internal calls bypass the guard
+
+The split between "framework may pass reserved keys" and "users may not" rests on
+an ActiveJob implementation detail, confirmed on ActiveJob 7.1.3.4:
+
+> `ActiveJob::ConfiguredJob` (returned by `.set(...)`) defines its own
+> `perform_now` / `perform_later` that build a fresh job instance and call the
+> **instance-level** enqueue path. They do **not** dispatch through the
+> **class-level** `perform_*` override.
+
+Therefore any enqueue routed through `.set(...)` bypasses the guard:
+
+- All framework continuations already use `.set(wait: …).perform_later(key, …)`
+  (`executor.rb:138`, `wait.rb`, `wait_until.rb`, `durably_repeat.rb`,
+  `durably_execute.rb`) — their `attempt:`/`retry_counts:`/`wait_condition:`
+  ride through untouched.
+- `retry_now` / `retry_later` are rewritten to enqueue via `set.perform_*`,
+  legitimately injecting `retry_workflow: true` past the guard.
+
+This dependency is non-obvious and now load-bearing, so it is documented inline
+at the guard.
+
+## Design
+
+All changes land in `lib/chrono_forge/executor.rb`, in the `class << base` block,
+plus one module-level constant. ~30 lines. No schema or behavior changes
+elsewhere.
+
+### 1. Reserved-key constant (module level, near `STEP_NAME_DELIMITER`)
+
+```ruby
+# Keyword args ChronoForge threads through job args internally. Users must not
+# pass these to perform_now/perform_later; the framework injects them via
+# `.set(...)` continuations, whose ConfiguredJob proxy bypasses the class-level
+# guard below.
+RESERVED_KWARGS = %i[attempt retry_counts retry_workflow].freeze
+```
+
+### 2. Public guards — `perform_now` / `perform_later`
+
+```ruby
+def perform_now(key, *extra, **kwargs)
+  __validate_enqueue!(key, extra, kwargs)
+  super(key, **kwargs)
+end
+
+def perform_later(key, *extra, **kwargs)
+  __validate_enqueue!(key, extra, kwargs)
+  super(key, **kwargs)
+end
+
+private
+
+def __validate_enqueue!(key, extra, kwargs)
+  unless key.is_a?(String)
+    raise ArgumentError, "Workflow key must be a string as the first argument"
+  end
+  unless extra.empty?
+    raise ArgumentError, "ChronoForge workflows accept only `key` positionally; " \
+      "pass everything else as keywords (got #{extra.size} extra positional arg(s))"
+  end
+  reserved = kwargs.keys & RESERVED_KWARGS
+  if reserved.any?
+    raise ArgumentError,
+      "#{reserved.join(", ")} #{reserved.one? ? "is a reserved" : "are reserved"} " \
+      "ChronoForge keyword(s) and cannot be passed to perform_now/perform_later"
+  end
+end
+```
+
+`*extra` exists solely to catch stray positionals and produce the clear error;
+after validation it is always empty and discarded (only `super(key, **kwargs)`
+is forwarded).
+
+### 3. Retry helpers — route past the guard
+
+```ruby
+def retry_now(key, **kwargs)
+  __validate_enqueue!(key, [], kwargs)
+  set.perform_now(key, retry_workflow: true, **kwargs)
+end
+
+def retry_later(key, **kwargs)
+  __validate_enqueue!(key, [], kwargs)
+  set.perform_later(key, retry_workflow: true, **kwargs)
+end
+```
+
+They still validate the *user's* kwargs (rejecting any reserved key the user
+supplied), then inject `retry_workflow: true` through the `ConfiguredJob` bypass.
+
+### 4. Framework continuations — unchanged
+
+`executor.rb:138`, `wait.rb`, `wait_until.rb`, `durably_repeat.rb`,
+`durably_execute.rb` already enqueue via `.set(...)`. No change required.
+
+## Scope / caveats
+
+- **Executor-only.** The guard lives in the `Executor`-prepended singleton.
+  `ChronoForge::CleanupJob` is a plain `ActiveJob::Base` and is unaffected
+  (its `perform_now(older_than_days: …)` / arg-less `perform_later` keep working).
+- **Backward compatible.** A full scan of `lib/` and `test/` found no call site
+  passing a second positional and no user call passing a reserved key, so the
+  existing suite passes unchanged.
+- **`wait_condition`** (internal kwarg in `wait_until`) is intentionally *not*
+  added to `RESERVED_KWARGS`: it only ever travels via `.set(...)` and so never
+  reaches the guard. Adding it later is a harmless one-line hygiene change if
+  desired.
+
+## Testing (TDD)
+
+New tests (Executor-prepended job):
+
+1. `perform_later` / `perform_now` raise `ArgumentError` when passed `attempt:`,
+   `retry_counts:`, or `retry_workflow:` — and the message names the key(s).
+2. `perform_later` / `perform_now` raise `ArgumentError` with the contract
+   message when passed a second positional argument.
+3. `perform_later("k", kwarg: "x", options: {a: 1})` still enqueues; `options`
+   and user kwargs reach the workflow (`workflow.options`, `workflow.kwargs`).
+4. `retry_now` / `retry_later` still unlock-and-continue a stalled workflow
+   (existing behavior preserved), and reject reserved keys passed by the caller.
+5. Non-String `key` still raises (regression guard for existing behavior).

--- a/lib/chrono_forge/executor.rb
+++ b/lib/chrono_forge/executor.rb
@@ -18,6 +18,12 @@ module ChronoForge
     # User-supplied names/methods must not contain it.
     STEP_NAME_DELIMITER = "$"
 
+    # Keyword args ChronoForge threads through job args internally. Users must
+    # not pass these to perform_now/perform_later; the framework injects them
+    # via `.set(...)` continuations, whose ConfiguredJob proxy bypasses the
+    # class-level guard in `prepended` below.
+    RESERVED_KWARGS = %i[attempt retry_counts retry_workflow].freeze
+
     include Methods
 
     # Add class methods
@@ -27,30 +33,31 @@ module ChronoForge
       base.class_attribute :default_retry_policy, instance_accessor: false, default: nil
 
       class << base
-        # Enforce expected signature for perform_now with key as first arg and keywords after
-        def perform_now(key, **kwargs)
-          if !key.is_a?(String)
-            raise ArgumentError, "Workflow key must be a string as the first argument"
-          end
-          super
+        # Public enqueue contract: exactly one positional (`key`) plus keywords.
+        # Reserved internal kwargs (RESERVED_KWARGS) are rejected here; the
+        # framework injects them only via `.set(...)` continuations, whose
+        # ActiveJob ConfiguredJob proxy bypasses these class-level overrides.
+        def perform_now(key, *extra, **kwargs)
+          __validate_enqueue!(key, extra, kwargs)
+          super(key, **kwargs)
         end
 
-        # Enforce expected signature for perform_later with key as first arg and keywords after
-        def perform_later(key, **kwargs)
-          if !key.is_a?(String)
-            raise ArgumentError, "Workflow key must be a string as the first argument"
-          end
-          super
+        def perform_later(key, *extra, **kwargs)
+          __validate_enqueue!(key, extra, kwargs)
+          super(key, **kwargs)
         end
 
-        # Add retry_now class method that calls perform_now with retry_workflow: true
-        def retry_now(key, **)
-          perform_now(key, retry_workflow: true, **)
+        # Re-run a failed/stalled workflow. Routes through `.set(...)` so the
+        # reserved `retry_workflow: true` flag reaches the instance perform
+        # without tripping the public guard above.
+        def retry_now(key, **kwargs)
+          __validate_enqueue!(key, [], kwargs)
+          set.perform_now(key, retry_workflow: true, **kwargs)
         end
 
-        # Add retry_later class method that calls perform_later with retry_workflow: true
-        def retry_later(key, **)
-          perform_later(key, retry_workflow: true, **)
+        def retry_later(key, **kwargs)
+          __validate_enqueue!(key, [], kwargs)
+          set.perform_later(key, retry_workflow: true, **kwargs)
         end
 
         # Class-level DSL to set this workflow's default retry policy. Applies to
@@ -65,6 +72,25 @@ module ChronoForge
 
           self.default_retry_policy =
             policies.any? ? RetryPolicy.compose(*policies) : RetryPolicy.new(**opts)
+        end
+
+        private
+
+        def __validate_enqueue!(key, extra, kwargs)
+          unless key.is_a?(String)
+            raise ArgumentError, "Workflow key must be a string as the first argument"
+          end
+          unless extra.empty?
+            raise ArgumentError,
+              "ChronoForge workflows accept only `key` positionally; pass " \
+              "everything else as keywords (got #{extra.size} extra positional arg(s))"
+          end
+          reserved = kwargs.keys & RESERVED_KWARGS
+          if reserved.any?
+            raise ArgumentError,
+              "#{reserved.join(", ")} #{reserved.one? ? "is a reserved" : "are reserved"} " \
+              "ChronoForge keyword(s) and cannot be passed to perform_now/perform_later"
+          end
         end
       end
     end

--- a/lib/chrono_forge/executor.rb
+++ b/lib/chrono_forge/executor.rb
@@ -89,7 +89,7 @@ module ChronoForge
           if reserved.any?
             raise ArgumentError,
               "#{reserved.join(", ")} #{reserved.one? ? "is a reserved" : "are reserved"} " \
-              "ChronoForge keyword(s) and cannot be passed to perform_now/perform_later"
+              "ChronoForge #{reserved.one? ? "keyword" : "keywords"} and cannot be passed to perform_now/perform_later"
           end
         end
       end

--- a/test/enqueue_contract_test.rb
+++ b/test/enqueue_contract_test.rb
@@ -7,8 +7,6 @@ require "test_helper"
 class EnqueueContractTest < ActiveJob::TestCase
   include ChaoticJob::Helpers
 
-  RESERVED = %i[attempt retry_counts retry_workflow].freeze
-
   def setup
     ChronoForge::Workflow.destroy_all
   end
@@ -23,7 +21,7 @@ class EnqueueContractTest < ActiveJob::TestCase
   # --- reserved-key rejection ------------------------------------------------
 
   def test_perform_later_rejects_reserved_keys
-    RESERVED.each do |reserved|
+    ChronoForge::Executor::RESERVED_KWARGS.each do |reserved|
       err = nil
       # assert_raises must sit inside the block-based assertion: Rails wraps the
       # block in assert_nothing_raised, which would otherwise rewrap our error.
@@ -38,7 +36,7 @@ class EnqueueContractTest < ActiveJob::TestCase
   end
 
   def test_perform_now_rejects_reserved_keys
-    RESERVED.each do |reserved|
+    ChronoForge::Executor::RESERVED_KWARGS.each do |reserved|
       err = assert_raises(ArgumentError) do
         ContractJob.perform_now("k-#{reserved}", reserved => 1)
       end

--- a/test/enqueue_contract_test.rb
+++ b/test/enqueue_contract_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+# Public enqueue contract for Executor-prepended jobs: perform_now/perform_later
+# accept exactly one positional (`key`) plus keywords, reject ChronoForge's
+# reserved internal kwargs, and pass `options`/user kwargs through to the
+# workflow record. retry_now/retry_later route past the guard via `.set(...)`.
+class EnqueueContractTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  RESERVED = %i[attempt retry_counts retry_workflow].freeze
+
+  def setup
+    ChronoForge::Workflow.destroy_all
+  end
+
+  class ContractJob < WorkflowJob
+    prepend ChronoForge::Executor
+    def perform(foo: nil)
+      context[:foo] = foo
+    end
+  end
+
+  # --- reserved-key rejection ------------------------------------------------
+
+  def test_perform_later_rejects_reserved_keys
+    RESERVED.each do |reserved|
+      err = nil
+      # assert_raises must sit inside the block-based assertion: Rails wraps the
+      # block in assert_nothing_raised, which would otherwise rewrap our error.
+      assert_no_enqueued_jobs do
+        err = assert_raises(ArgumentError) do
+          ContractJob.perform_later("k-#{reserved}", reserved => 1)
+        end
+      end
+      assert_match(/reserved/, err.message)
+      assert_match(reserved.to_s, err.message)
+    end
+  end
+
+  def test_perform_now_rejects_reserved_keys
+    RESERVED.each do |reserved|
+      err = assert_raises(ArgumentError) do
+        ContractJob.perform_now("k-#{reserved}", reserved => 1)
+      end
+      assert_match(/reserved/, err.message)
+    end
+  end
+
+  # --- keywords-only contract ------------------------------------------------
+
+  def test_perform_later_rejects_extra_positional
+    err = nil
+    assert_no_enqueued_jobs do
+      err = assert_raises(ArgumentError) { ContractJob.perform_later("k", 99) }
+    end
+    assert_match(/keyword/, err.message)
+  end
+
+  def test_perform_now_rejects_extra_positional
+    err = assert_raises(ArgumentError) { ContractJob.perform_now("k", 99) }
+    assert_match(/keyword/, err.message)
+  end
+
+  def test_non_string_key_still_rejected
+    assert_raises(ArgumentError) { ContractJob.perform_later(123) }
+    assert_raises(ArgumentError) { ContractJob.perform_now(123) }
+  end
+
+  # --- public kwargs pass through --------------------------------------------
+
+  def test_options_and_user_kwargs_pass_through
+    key = "contract-#{SecureRandom.hex(4)}"
+    ContractJob.perform_later(key, foo: "bar", options: {plan: "pro"})
+    perform_all_jobs
+
+    wf = ChronoForge::Workflow.find_by(key: key)
+    assert_equal({"plan" => "pro"}, wf.options)
+    assert_equal "bar", wf.kwargs["foo"]
+    assert_equal "bar", wf.context["foo"]
+  end
+
+  # --- retry helpers route past the guard ------------------------------------
+
+  def test_retry_helpers_reject_reserved_keys_from_caller
+    assert_raises(ArgumentError) { ContractJob.retry_now("k", attempt: 1) }
+    assert_raises(ArgumentError) { ContractJob.retry_later("k", attempt: 1) }
+  end
+end


### PR DESCRIPTION
## Summary

Hardens the public enqueue surface of `Executor`-prepended workflow jobs so that ChronoForge's internal plumbing can't be silently hijacked by caller kwargs, and so contract violations fail loudly at enqueue time instead of mysteriously inside the worker.

- **Reject reserved kwargs.** `perform_now`/`perform_later` now raise a clear `ArgumentError` if a caller passes `attempt`, `retry_counts`, or `retry_workflow` (the keys the framework threads through job args internally). Previously these silently collided with a user's own kwargs and corrupted retry state.
- **Keywords-only contract.** Exactly one positional argument (`key`) is allowed; any extra positional is rejected with a contract-specific message rather than Ruby's generic arity error. This matches the existing keyword-only replay (`super(**workflow.kwargs.symbolize_keys)`), so positionals beyond `key` could never have worked anyway.
- **`options` and user kwargs still pass through** untouched to the workflow record.
- **`retry_now`/`retry_later` rewritten** to enqueue via `.set(...)`, whose ActiveJob `ConfiguredJob` proxy bypasses the class-level override — letting the framework legitimately inject `retry_workflow: true` past the guard while still validating caller-supplied kwargs. Framework continuations (`wait`, `wait_until`, `durably_repeat`, `durably_execute`, the internal retry re-enqueue) already use `.set(...)` and are unchanged.

A single private `__validate_enqueue!` backs all four entry points; `RESERVED_KWARGS` is the one source of truth.

Design + plan: `docs/superpowers/specs/2026-06-25-reserved-kwarg-guard-design.md`, `docs/superpowers/plans/2026-06-25-reserved-kwarg-guard.md`.

## Test Plan

- [x] New `test/enqueue_contract_test.rb` (7 tests): reserved-key rejection on both methods, extra-positional rejection, non-String key, `options`/kwargs pass-through to the persisted workflow, and `retry_*` rejecting caller-supplied reserved keys.
- [x] Full suite green: `bundle exec rake test` → 146 tests, 609 assertions, 0 failures, 0 errors.
- [x] Existing retry end-to-end tests (`test/workflow_retry_api_test.rb`, `test/chrono_forge_test.rb`) still pass, exercising the `.set`-based `retry_*` routing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)