### PR TITLE
feat(branches): concurrent sub-workflows (spawn / spawn_each / merge_branches / automerge)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,3 +25,40 @@ jobs:
           bundler-cache: true
       - name: Appraise
         run: bundle exec appraisal install && bin/appraise
+
+  migration-safety:
+    runs-on: ubuntu-latest
+    name: Migration safety (PostgreSQL + strong_migrations)
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: chrono_forge_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DB_ADAPTER: postgresql
+      DB_DATABASE: chrono_forge_test
+      DB_HOST: localhost
+      DB_PORT: "5432"
+      DB_USERNAME: postgres
+      DB_PASSWORD: postgres
+      BUNDLE_WITH: postgres
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2.2"
+          bundler-cache: true
+      # Booting the internal app makes Combustion reset + run every gem migration
+      # under strong_migrations on PostgreSQL; an unsafe migration raises
+      # StrongMigrations::UnsafeMigration and fails this job.
+      - name: Run gem migrations under strong_migrations (PostgreSQL)
+        run: bundle exec ruby -I test test/schema_test.rb

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,10 @@ source "https://rubygems.org"
 gemspec
 
 gem "sqlite3", "~> 1.4"
+
+# Only the Postgres CI lane installs this (BUNDLE_WITH=postgres) to run the gem's
+# migrations under strong_migrations on PostgreSQL. Default (SQLite) bundles skip it,
+# so contributors don't need libpq locally.
+group :postgres, optional: true do
+  gem "pg"
+end

--- a/README.md
+++ b/README.md
@@ -879,6 +879,86 @@ production:
     schedule: every day at 3am
 ```
 
+## 🌿 Branches: parallel sub-workflows
+
+`branch` / `spawn` / `spawn_each` / `merge_branches` let a workflow fan out into
+child workflows that run concurrently, then join them when their results are
+needed.
+
+### Model
+
+- **`branch :name do … end`** opens a named branch (a durable step). Inside the
+  block, `spawn` and `spawn_each` create and immediately enqueue child workflows —
+  children start running as soon as the branch block is entered.
+- **`spawn :name, WorkflowClass, **kwargs`** — enqueues one child workflow.
+- **`spawn_each :name, source do |item| [WorkflowClass, kwargs] end`** — enqueues
+  one child per item. The block returns the class and kwargs, so one branch can
+  fan out into mixed workflow types. Sources are iterated in constant memory;
+  ActiveRecord relations are streamed by primary key — pass them **without** an
+  explicit `.order`.
+- **`automerge: true`** — joins the branch **inline at the block's close**.
+  Execution does not continue past the `branch` call until every child has
+  completed. Use it for "dispatch this group and wait right here."
+- **`merge_branches :a, :b`** (or the singular alias `merge_branch :a`) — the
+  separate join point. Open branches without `automerge`, do other work while the
+  children run, then join when you need their results. `merge_branches` blocks
+  until all named branches are complete.
+
+### Worked example
+
+```ruby
+class FulfillmentWorkflow < ApplicationJob
+  prepend ChronoForge::Executor
+
+  def perform(cycle_id:)
+    # automerge: the branch is joined inline, right where the block closes —
+    # `perform` does not continue past it until every child has completed.
+    branch :reconcile, automerge: true do
+      spawn :eu, ReconcileWorkflow, region: "EU"
+      spawn_each :orders, Order.pending do |order|
+        order.priority? ? [PriorityOrderWorkflow, { order_id: order.id }]
+                        : [OrderWorkflow, { order_id: order.id }]
+      end
+    end
+
+    # For branches you want to run concurrently and join later, omit automerge
+    # and use merge_branches:
+    branch :invoices do
+      spawn_each :unpaid, Invoice.unpaid do |inv|
+        [InvoiceWorkflow, { invoice_id: inv.id }]
+      end
+    end
+    branch :shipments do
+      spawn_each :ready, Shipment.ready do |s|
+        [ShipmentWorkflow, { shipment_id: s.id }]
+      end
+    end
+    do_other_work                        # runs while :invoices and :shipments dispatch/run
+    merge_branches :invoices, :shipments # join both here
+
+    durably_execute :finalize
+  end
+end
+```
+
+### Caveats
+
+> **Every branch must be joined.** A branch opened and never joined raises
+> `ChronoForge::Executor::UnmergedBranchError` when the workflow tries to
+> complete — fail-fast, no silently-orphaned children. Use either
+> `automerge: true` or a matching `merge_branches` call.
+
+> **The parent isn't replayed while waiting.** A lightweight
+> `ChronoForge::BranchMergeJob` polls for child completion; the parent workflow
+> only runs again once the branch is fully done. Polling cadence adapts to how
+> many children remain.
+
+> **`spawn_each` sources must re-enumerate deterministically across replays.**
+> ActiveRecord relations are streamed by primary key (children are keyed by
+> record id, so crash-resume is idempotent); a relation carrying an explicit
+> `.order(...)` raises. For non-AR enumerables, items are keyed by position, so
+> inserting or removing items mid-dispatch would shift keys and break idempotency.
+
 ## 🚀 Development
 
 After checking out the repo, run:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ ChronoForge handles long-running processes, manages state, and recovers from fai
 
 Workflows are **plain Ruby**. Ordinary `if`/`else`, loops, and early returns drive the flow. There's no declarative DSL to learn and no extra service to run, which makes ChronoForge a good fit for business processes whose shape depends on runtime state: conditional branches, iteration over data, and built-in periodic tasks (`durably_repeat`).
 
-> **In production:** ChronoForge runs financial workflows at **achieve by Petra**, an investment platform in the Petra Group.
+> **In production:** ChronoForge has run **over 3.5 million workflow executions** at **achieve by Petra**, an investment platform in the Petra Group — powering scheduled payments, investment rollovers, and reward-membership lifecycle management.
 
 ## 🧭 Why ChronoForge
 

--- a/README.md
+++ b/README.md
@@ -959,6 +959,18 @@ end
 > `.order(...)` raises. For non-AR enumerables, items are keyed by position, so
 > inserting or removing items mid-dispatch would shift keys and break idempotency.
 
+> **`spawn_each` AR sources must have stable membership.** Dispatch streams by
+> ascending primary key and resumes from the last key on crash-recovery, so a row
+> that enters the relation *below* the cursor after it has passed (e.g. a
+> `where(state: …)` scope whose rows mutate mid-dispatch) will never get a child.
+> Point `spawn_each` at a set that is fixed for the branch's lifetime — a frozen id
+> range, an append-only table, or `where(id: [...])` over a snapshot.
+
+> **`branch` blocks cannot be lexically nested within one workflow.** Opening a
+> `branch` inside another `branch` block raises `ArgumentError`; spawns belong to
+> exactly one branch. (A *spawned child workflow* may open its own branches — it
+> runs in its own executor — so cross-workflow nesting is fine.)
+
 ## 🚀 Development
 
 After checking out the repo, run:

--- a/chrono_forge.gemspec
+++ b/chrono_forge.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activerecord"
-  spec.add_dependency "activejob"
+  spec.add_dependency "activejob", ">= 7.1"
   spec.add_dependency "zeitwerk"
 
   spec.add_development_dependency "rake"

--- a/chrono_forge.gemspec
+++ b/chrono_forge.gemspec
@@ -46,4 +46,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "combustion"
   spec.add_development_dependency "chaotic_job"
+  # Lints the gem's own migration templates for safety (concurrent indexes,
+  # no blocking column rewrites) when the test suite runs them via Combustion.
+  spec.add_development_dependency "strong_migrations"
 end

--- a/docs/superpowers/plans/2026-06-26-branches-spawn-merge.md
+++ b/docs/superpowers/plans/2026-06-26-branches-spawn-merge.md
@@ -1,0 +1,1378 @@
+# Branches (`branch` / `spawn` / `spawn_each` / `merge_branches`) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers-extended-cc:subagent-driven-development (recommended) or superpowers-extended-cc:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a durable, large-scale fan-out/fan-in primitive to ChronoForge — `branch` blocks that `spawn`/`spawn_each` child sub-workflows and are joined by `merge_branches` (or `automerge`), built to dispatch hundreds of thousands of children per branch.
+
+**Architecture:** A `branch :name do … end` block is a durable coordination step (`branch$<name>` execution log). Inside it, `spawn`/`spawn_each` eagerly create + bulk-enqueue child workflows (one `chrono_forge_workflows` row each, linked by a new generic `parent_execution_log_id` FK to the branch log). The block seals when it closes; `spawn_each` streams its source with a per-spawn cursor so dispatch resumes after a crash without re-streaming. Joining is poll-based via a lightweight `BranchMergeJob` (no parent replay per poll); branch/merge state is tracked in an in-memory registry (`@open_branches`) rebuilt each replay pass, so the completion gate can raise on a forgotten join.
+
+**Tech Stack:** Ruby, ActiveJob (>= 7.1, for `perform_all_later`), ActiveRecord, Zeitwerk, Minitest + Combustion + ChaoticJob.
+
+**User Verification:** NO — no user verification required (library feature; verified by the test suite).
+
+**Reference spec:** `docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md`
+
+---
+
+## File Structure
+
+**New library files**
+- `lib/chrono_forge/executor/methods/branch.rb` — `branch`, `spawn`, `spawn_each`, and shared dispatch/cursor/registry helpers.
+- `lib/chrono_forge/executor/methods/merge_branches.rb` — `merge_branches`/`merge_branch`, plus `branches_done?` / `enqueue_branch_merge_job` / `open_branch!` (used by the completion gate too).
+- `lib/chrono_forge/branch_merge_job.rb` — `ChronoForge::BranchMergeJob`, the lightweight poller.
+- `lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb` — additive migration.
+
+**Modified library files**
+- `lib/chrono_forge/executor.rb` — new error classes; `include Methods::Branch` / `Methods::MergeBranches` (via methods.rb); poll-cadence constants.
+- `lib/chrono_forge/executor/methods.rb` — include the two new modules.
+- `lib/chrono_forge/executor/methods/workflow_states.rb` — completion gate in `complete_workflow!`.
+- `lib/chrono_forge/workflow.rb` — `belongs_to :parent_execution_log`.
+- `lib/chrono_forge/execution_log.rb` — `has_many :spawned_workflows`.
+- `lib/generators/chrono_forge/migration_actions.rb` — add migration to `MIGRATIONS`.
+- `chrono_forge.gemspec` — `activejob >= 7.1` floor.
+- `README.md` — branch/merge section + caveats.
+
+**New/modified test files**
+- `test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb` — apply the column to the test DB.
+- `test/internal/app/jobs/` — branch test workflow jobs + a trivial child workflow.
+- `test/branch_test.rb`, `test/spawn_each_test.rb`, `test/branch_merge_job_test.rb`, `test/merge_branches_test.rb`, `test/automerge_test.rb`, `test/branch_recovery_test.rb`, `test/branch_scale_test.rb`.
+- `test/schema_test.rb`, `test/generators_test.rb`, `test/upgrade_migration_test.rb` — extend for the new column/index.
+
+---
+
+### Task 1: Schema — `parent_execution_log_id` column + `(parent_execution_log_id, state)` index
+
+**Goal:** Add a generic `parent_execution_log_id` FK column to `chrono_forge_workflows` with a composite index on `(parent_execution_log_id, state)`, shipped as an additive migration wired into the install/upgrade generators and applied to the test DB.
+
+**Files:**
+- Create: `lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb`
+- Modify: `lib/generators/chrono_forge/migration_actions.rb`
+- Create: `test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb`
+- Modify: `test/schema_test.rb`, `test/generators_test.rb`
+
+**Acceptance Criteria:**
+- [ ] `chrono_forge_workflows` has a nullable `parent_execution_log_id` column whose type matches the table's primary-key type (bigint or uuid).
+- [ ] A composite index `(parent_execution_log_id, state)` exists.
+- [ ] The migration is idempotent (`if_not_exists`) and listed in `MigrationActions::MIGRATIONS`.
+- [ ] `generators_test` expects the new migration in the copied set.
+
+**Verify:** `cd .worktrees/branches && bundle exec ruby -I test test/schema_test.rb` → all pass
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing schema test**
+
+Add to `test/schema_test.rb` (inside the existing `SchemaTest`):
+
+```ruby
+  def test_workflows_have_parent_execution_log_id_column
+    assert connection.column_exists?(:chrono_forge_workflows, :parent_execution_log_id),
+      "expected chrono_forge_workflows.parent_execution_log_id for branch children"
+  end
+
+  def test_workflows_have_parent_execution_log_state_index
+    assert connection.index_exists?(:chrono_forge_workflows, %i[parent_execution_log_id state]),
+      "expected composite index on [parent_execution_log_id, state] for the merge probe"
+  end
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bundle exec ruby -I test test/schema_test.rb -n test_workflows_have_parent_execution_log_id_column`
+Expected: FAIL — column does not exist.
+
+- [ ] **Step 3: Write the migration template**
+
+Create `lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb`:
+
+```ruby
+# frozen_string_literal: true
+
+# Adds chrono_forge_workflows.parent_execution_log_id: the execution log that
+# spawned a workflow (for branches, the branch$<name> log). Deliberately generic
+# so any future step that spawns sub-workflows can reuse it. The composite
+# [parent_execution_log_id, state] index makes the merge completion probe and the
+# dropped-job re-kick index-only at hundreds of thousands of children.
+#
+# Shipped standalone (matching add_chrono_forge_workflow_state_index) so existing
+# installs pick it up via `rails generate chrono_forge:upgrade`.
+class AddChronoForgeParentExecutionLog < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :chrono_forge_workflows, :parent_execution_log_id, parent_log_fk_type,
+      null: true, if_not_exists: true
+
+    add_index :chrono_forge_workflows, %i[parent_execution_log_id state],
+      if_not_exists: true, **chrono_forge_index_algorithm
+  end
+
+  private
+
+  # Match the type of chrono_forge_workflows.id so the FK lines up on both bigint
+  # and uuid installs.
+  def parent_log_fk_type
+    id_col = connection.columns(:chrono_forge_workflows).find { |c| c.name == "id" }
+    id_col && id_col.sql_type.to_s.downcase.include?("uuid") ? :uuid : :bigint
+  end
+
+  def chrono_forge_index_algorithm
+    if connection.adapter_name.to_s.downcase.include?("postgresql")
+      {algorithm: :concurrently}
+    else
+      {}
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Wire it into the generators**
+
+In `lib/generators/chrono_forge/migration_actions.rb`, append to `MIGRATIONS`:
+
+```ruby
+      MIGRATIONS = %w[
+        install_chrono_forge
+        add_chrono_forge_workflow_state_index
+        add_chrono_forge_error_log_step_context
+        add_chrono_forge_parent_execution_log
+      ].freeze
+```
+
+Update `test/generators_test.rb` `test_install_copies_all_migrations` expected list to include `"add_chrono_forge_parent_execution_log.rb"` (keep it alphabetically sorted as the test sorts), and bump the idempotence count in `test_install_is_idempotent` from `3` to `4`.
+
+- [ ] **Step 5: Apply to the test DB**
+
+Create `test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb` with the **same class body** as the template (Combustion runs these migrations to build the test schema):
+
+```ruby
+# frozen_string_literal: true
+
+require_relative "../../../../lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log"
+```
+
+(If the `require_relative` shortcut causes Combustion load-order issues, instead paste the full class body from Step 3 into this file verbatim.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `bundle exec ruby -I test test/schema_test.rb && bundle exec ruby -I test test/generators_test.rb`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/generators test/internal/db/migrate test/schema_test.rb test/generators_test.rb
+git commit -m "feat(branches): add parent_execution_log_id column + index"
+```
+
+```json:metadata
+{"files": ["lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb", "lib/generators/chrono_forge/migration_actions.rb", "test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb", "test/schema_test.rb", "test/generators_test.rb"], "verifyCommand": "bundle exec ruby -I test test/schema_test.rb", "acceptanceCriteria": ["parent_execution_log_id column exists", "composite (parent_execution_log_id, state) index exists", "migration listed in MIGRATIONS and generators_test"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 2: Model associations
+
+**Goal:** Link children to their spawning branch log via ActiveRecord associations.
+
+**Files:**
+- Modify: `lib/chrono_forge/workflow.rb`
+- Modify: `lib/chrono_forge/execution_log.rb`
+- Test: `test/branch_associations_test.rb`
+
+**Acceptance Criteria:**
+- [ ] `Workflow#parent_execution_log` returns the spawning `ExecutionLog` (optional).
+- [ ] `ExecutionLog#spawned_workflows` returns the workflows it spawned.
+
+**Verify:** `bundle exec ruby -I test test/branch_associations_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/branch_associations_test.rb`:
+
+```ruby
+require "test_helper"
+
+class BranchAssociationsTest < ActiveJob::TestCase
+  def test_parent_execution_log_and_spawned_workflows_round_trip
+    parent = ChronoForge::Workflow.create!(key: "p-#{SecureRandom.hex}", job_class: "X")
+    log = parent.execution_logs.create!(step_name: "branch$grp")
+    child = ChronoForge::Workflow.create!(
+      key: "c-#{SecureRandom.hex}", job_class: "Y", parent_execution_log_id: log.id
+    )
+
+    assert_equal log, child.parent_execution_log
+    assert_includes log.spawned_workflows, child
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `bundle exec ruby -I test test/branch_associations_test.rb`
+Expected: FAIL — `NoMethodError: undefined method 'parent_execution_log'`.
+
+- [ ] **Step 3: Add the associations**
+
+In `lib/chrono_forge/workflow.rb`, after `has_many :error_logs, dependent: :destroy`:
+
+```ruby
+    belongs_to :parent_execution_log,
+      class_name: "ChronoForge::ExecutionLog", optional: true
+```
+
+In `lib/chrono_forge/execution_log.rb`, after `belongs_to :workflow`:
+
+```ruby
+    has_many :spawned_workflows,
+      class_name: "ChronoForge::Workflow",
+      foreign_key: :parent_execution_log_id,
+      inverse_of: :parent_execution_log,
+      dependent: :nullify
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `bundle exec ruby -I test test/branch_associations_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/chrono_forge/workflow.rb lib/chrono_forge/execution_log.rb test/branch_associations_test.rb
+git commit -m "feat(branches): parent_execution_log / spawned_workflows associations"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/workflow.rb", "lib/chrono_forge/execution_log.rb", "test/branch_associations_test.rb"], "verifyCommand": "bundle exec ruby -I test test/branch_associations_test.rb", "acceptanceCriteria": ["parent_execution_log association", "spawned_workflows association"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 3: `branch` + `spawn` (block, registry, eager single dispatch, seal, skip-on-replay)
+
+**Goal:** Implement the `branch` block (durable step, in-memory registry, seal-on-close, **skip-the-block-when-sealed**) and `spawn` (single eager child dispatch). `spawn` outside a branch raises.
+
+**Files:**
+- Create: `lib/chrono_forge/executor/methods/branch.rb`
+- Modify: `lib/chrono_forge/executor.rb` (error classes)
+- Modify: `lib/chrono_forge/executor/methods.rb` (include)
+- Create: `test/internal/app/jobs/single_spawn_workflow.rb`, `test/internal/app/jobs/noop_child.rb`
+- Create: `test/branch_test.rb`
+
+**Acceptance Criteria:**
+- [ ] `branch :g do spawn :c, NoopChild end` creates a child with key `"<parent.key>$g$c"`, `job_class: "NoopChild"`, `parent_execution_log_id` = the `branch$g` log id, `state: idle`.
+- [ ] The `branch$g` log is `completed` (sealed) after the block closes.
+- [ ] On replay (sealed), the block body is **not** re-executed (no duplicate child rows, no re-dispatch).
+- [ ] `spawn` called outside a `branch` block raises `NotInBranchError`.
+
+**Verify:** `bundle exec ruby -I test test/branch_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests + fixtures**
+
+Create `test/internal/app/jobs/noop_child.rb`:
+
+```ruby
+class NoopChild < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(**)
+    durably_execute :noop
+  end
+
+  private
+
+  def noop = nil
+end
+```
+
+Create `test/internal/app/jobs/single_spawn_workflow.rb`:
+
+```ruby
+class SingleSpawnWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :grp, automerge: true do
+      spawn :child, NoopChild, foo: "bar"
+    end
+  end
+end
+```
+
+Create `test/branch_test.rb`:
+
+```ruby
+require "test_helper"
+
+class BranchTest < ActiveJob::TestCase
+  def test_spawn_creates_linked_child_and_seals_branch
+    SingleSpawnWorkflow.perform_later("ss-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "ss-1")
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    assert branch_log.completed?, "branch should seal when the block closes"
+
+    child = ChronoForge::Workflow.find_by(key: "ss-1$grp$child")
+    assert child, "child should be created with deterministic key"
+    assert_equal "NoopChild", child.job_class
+    assert_equal branch_log.id, child.parent_execution_log_id
+    assert_equal({"foo" => "bar"}, child.kwargs)
+  end
+
+  def test_spawn_outside_branch_raises
+    workflow = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform = spawn(:x, NoopChild)
+    end
+    Object.const_set(:BareSpawnWorkflow, workflow)
+    BareSpawnWorkflow.perform_later("bare-1")
+    assert_raises(ChronoForge::Executor::NotInBranchError) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :BareSpawnWorkflow) if defined?(BareSpawnWorkflow)
+  end
+
+  def test_sealed_branch_block_is_not_re_executed_on_replay
+    # First run dispatches + seals.
+    SingleSpawnWorkflow.perform_later("ss-2")
+    perform_all_jobs
+    branch_log = ChronoForge::Workflow.find_by(key: "ss-2").execution_logs.find_by(step_name: "branch$grp")
+
+    # Re-run the same workflow key: the sealed branch must skip its block.
+    inserts = 0
+    sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*a|
+      inserts += 1 if /INSERT INTO ["`]?chrono_forge_workflows/i.match?(a.last[:sql].to_s)
+    end
+    SingleSpawnWorkflow.perform_later("ss-2")
+    perform_all_jobs
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    assert_equal 0, inserts, "sealed branch must not re-dispatch children on replay"
+    assert_equal 1, ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).count
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bundle exec ruby -I test test/branch_test.rb`
+Expected: FAIL — `NameError: uninitialized constant ... NotInBranchError` / `NoMethodError: branch`.
+
+- [ ] **Step 3: Add the error classes**
+
+In `lib/chrono_forge/executor.rb`, after `class InvalidStepName < NotExecutableError; end`:
+
+```ruby
+    # spawn/spawn_each called outside a branch block. NotExecutableError so it
+    # propagates (fail-fast on a programming error) rather than being retried.
+    class NotInBranchError < NotExecutableError; end
+
+    # A branch was opened but neither merged via merge_branches nor declared
+    # automerge: true. Raised at the completion gate. Fail-fast (not retried).
+    class UnmergedBranchError < NotExecutableError; end
+```
+
+- [ ] **Step 4: Implement `branch` + `spawn` + shared helpers**
+
+Create `lib/chrono_forge/executor/methods/branch.rb`:
+
+```ruby
+module ChronoForge
+  module Executor
+    module Methods
+      module Branch
+        # Opens a named branch — a durable fan-out step. Spawns inside the block
+        # eagerly create + enqueue child workflows; the branch SEALS when the
+        # block closes. Returns without waiting (branches are concurrent; the
+        # join is a separate merge_branches / automerge).
+        def branch(name, automerge: false)
+          raise ArgumentError, "branch requires a block" unless block_given?
+          raise ArgumentError, "branch blocks cannot be nested" if @current_branch
+          validate_step_name_segment!(name)
+
+          step_name = "branch$#{name}"
+          log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }
+
+          # The sealed branch log may be a readonly, id-less cache stand-in; fetch
+          # the real id so the registry/merge can scope children to it.
+          log_id = log.id || ExecutionLog.where(workflow: @workflow, step_name: step_name).pick(:id)
+          (@open_branches ||= {})[name.to_s] = {automerge: automerge, log_id: log_id}
+
+          # ---- THE single most important correctness/performance property ----
+          # A SEALED branch skips its block ENTIRELY. The expensive source
+          # enumeration in spawn_each never re-runs after sealing. Do not move
+          # dispatch out from behind this guard.
+          unless log.completed?
+            @current_branch = {name: name.to_s, log: log, seq: 0}
+            begin
+              yield
+            ensure
+              @current_branch = nil
+            end
+            log.update!(state: :completed, completed_at: Time.current)
+          end
+
+          name
+        end
+
+        # Dispatch a single child into the current branch.
+        def spawn(name, workflow_class, **kwargs)
+          cb = current_branch!
+          validate_step_name_segment!(name)
+          child_key = "#{@workflow.key}$#{cb[:name]}$#{name}"
+          dispatch_children(cb, [[child_key, workflow_class, kwargs]])
+          name
+        end
+
+        private
+
+        def current_branch!
+          @current_branch || raise(NotInBranchError, "spawn/spawn_each may only be called inside a branch block")
+        end
+
+        # Bulk-create child workflow rows then bulk-enqueue their jobs.
+        # perform_all_later bypasses the class-level perform_later guard, so we
+        # validate the args ourselves before enqueuing.
+        def dispatch_children(cb, entries)
+          return if entries.empty?
+          now = Time.current
+          rows = entries.map do |child_key, klass, kwargs|
+            validate_child_enqueue!(child_key, kwargs)
+            {
+              key: child_key, job_class: klass.to_s,
+              kwargs: kwargs, options: {}, context: {},
+              state: Workflow.states[:idle],
+              parent_execution_log_id: cb[:log].id,
+              created_at: now, updated_at: now
+            }
+          end
+          # On-conflict-ignore makes re-dispatch (crash recovery) idempotent.
+          Workflow.insert_all(rows, unique_by: :key)
+          jobs = entries.map { |child_key, klass, kwargs| klass.new(child_key, **kwargs) }
+          ActiveJob.perform_all_later(jobs)
+        end
+
+        def validate_child_enqueue!(child_key, kwargs)
+          unless child_key.is_a?(String)
+            raise ArgumentError, "child key must be a String (got #{child_key.inspect})"
+          end
+          reserved = kwargs.keys.map(&:to_sym) & RESERVED_KWARGS
+          if reserved.any?
+            raise ArgumentError, "#{reserved.join(", ")} are reserved ChronoForge keywords"
+          end
+        end
+
+        # Advance (and persist) a spawn_each cursor on the branch log.
+        # `n` is the running item index; `pk` is the AR keyset position (nil for
+        # plain enumerables).
+        def advance_cursor!(cb, spawn_name, n:, pk: nil)
+          meta = cb[:log].metadata || {}
+          cursors = meta["cursors"] || {}
+          entry = cursors[spawn_name.to_s] || {}
+          entry["n"] = n
+          entry["pk"] = pk unless pk.nil?
+          cursors[spawn_name.to_s] = entry
+          meta["cursors"] = cursors
+          cb[:log].update!(metadata: meta)
+        end
+      end
+    end
+  end
+end
+```
+
+In `lib/chrono_forge/executor/methods.rb`, add the include (place `Branch` before `WorkflowStates` so its private helpers are available to the completion gate):
+
+```ruby
+module ChronoForge
+  module Executor
+    module Methods
+      include Methods::Wait
+      include Methods::WaitUntil
+      include Methods::ContinueIf
+      include Methods::DurablyExecute
+      include Methods::DurablyRepeat
+      include Methods::Branch
+      include Methods::MergeBranches
+      include Methods::WorkflowStates
+    end
+  end
+end
+```
+
+> Note: `Methods::MergeBranches` is referenced here but created in Task 6. Until then, add a temporary empty module to keep the suite loading, OR implement Task 6 immediately after this task. The subagent executing this plan should create `merge_branches.rb` with at least `module ChronoForge; module Executor; module Methods; module MergeBranches; end; end; end; end` now and flesh it out in Task 6.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `bundle exec ruby -I test test/branch_test.rb`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/chrono_forge test/internal/app/jobs/noop_child.rb test/internal/app/jobs/single_spawn_workflow.rb test/branch_test.rb
+git commit -m "feat(branches): branch block + spawn single child"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/executor/methods/branch.rb", "lib/chrono_forge/executor.rb", "lib/chrono_forge/executor/methods.rb", "test/branch_test.rb", "test/internal/app/jobs/noop_child.rb", "test/internal/app/jobs/single_spawn_workflow.rb"], "verifyCommand": "bundle exec ruby -I test test/branch_test.rb", "acceptanceCriteria": ["spawn creates linked child + seals branch", "spawn outside branch raises NotInBranchError", "sealed branch skips block on replay"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 4: `spawn_each` — streaming bulk dispatch with cursor
+
+**Goal:** Implement `spawn_each(name, source, of:)` — stream an AR relation (keyset) or any enumerable, dispatching one child per item keyed `name_{index}`, with the class returned from the block and a resumable per-spawn cursor. Raise on a conflicting AR `.order`.
+
+**Files:**
+- Modify: `lib/chrono_forge/executor/methods/branch.rb`
+- Create: `test/internal/app/jobs/spawn_each_workflow.rb`
+- Create: `test/spawn_each_test.rb`
+
+**Acceptance Criteria:**
+- [ ] `spawn_each :items, User.all` over N users creates N children keyed `<parent.key>$grp$items_0 … items_{N-1}`, each `parent_execution_log_id` = the branch log.
+- [ ] The block's returned class is honored per item (mixed classes supported).
+- [ ] An AR relation with an explicit conflicting `.order(...)` raises (via `error_on_ignore: true`).
+- [ ] A plain enumerable source works (offset cursor).
+- [ ] Cursor `{ "pk" =>, "n" => }` is persisted under `metadata.cursors[name]`.
+
+**Verify:** `bundle exec ruby -I test test/spawn_each_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests + fixtures**
+
+Create `test/internal/app/jobs/spawn_each_workflow.rb`:
+
+```ruby
+class SpawnEachWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(of: 1000)
+    branch :grp, automerge: true do
+      spawn_each :items, User.order(:id), of: of do |user|
+        [NoopChild, {user_id: user.id}]
+      end
+    end
+  end
+end
+```
+
+Create `test/spawn_each_test.rb`:
+
+```ruby
+require "test_helper"
+
+class SpawnEachTest < ActiveJob::TestCase
+  def setup
+    User.delete_all
+    @users = 5.times.map { |i| User.create!(name: "u#{i}", email: "u#{i}@e.com") }
+  end
+
+  def test_spawn_each_creates_one_indexed_child_per_item
+    SpawnEachWorkflow.perform_later("se-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "se-1")
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).order(:key)
+
+    assert_equal 5, children.count
+    assert_equal (0..4).map { |i| "se-1$grp$items_#{i}" }, children.pluck(:key)
+    assert_equal [@users.first.id], [children.first.kwargs["user_id"]]
+    cursor = branch_log.reload.metadata["cursors"]["items"]
+    assert_equal 5, cursor["n"]
+  end
+
+  def test_spawn_each_honors_class_from_block
+    klass = Class.new(WorkflowJob) { prepend ChronoForge::Executor; def perform(**) = nil }
+    Object.const_set(:AltChild, klass)
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:g, automerge: true) do
+          spawn_each(:i, User.order(:id)) { |u| u.id.even? ? [AltChild, {id: u.id}] : [NoopChild, {id: u.id}] }
+        end
+      end
+    end
+    Object.const_set(:MixedClassWorkflow, job)
+
+    MixedClassWorkflow.perform_later("mc-1")
+    perform_all_jobs
+
+    classes = ChronoForge::Workflow.where("key LIKE ?", "mc-1$g$i_%").pluck(:job_class).uniq.sort
+    assert_equal %w[AltChild NoopChild], classes
+  ensure
+    Object.send(:remove_const, :AltChild) if defined?(AltChild)
+    Object.send(:remove_const, :MixedClassWorkflow) if defined?(MixedClassWorkflow)
+  end
+
+  def test_spawn_each_raises_on_conflicting_order
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:g, automerge: true) do
+          spawn_each(:i, User.order(:email)) { |u| [NoopChild, {id: u.id}] }
+        end
+      end
+    end
+    Object.const_set(:BadOrderWorkflow, job)
+    BadOrderWorkflow.perform_later("bo-1")
+    assert_raises(ActiveRecord::IrreversibleOrderError) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :BadOrderWorkflow) if defined?(BadOrderWorkflow)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bundle exec ruby -I test test/spawn_each_test.rb`
+Expected: FAIL — `NoMethodError: spawn_each`.
+
+- [ ] **Step 3: Implement `spawn_each`**
+
+Add to `lib/chrono_forge/executor/methods/branch.rb` (in module `Branch`, public, next to `spawn`):
+
+```ruby
+        # Dispatch one child per item of `source`, streamed. AR relations use
+        # keyset iteration (in_batches start:) for constant memory; any other
+        # enumerable uses an offset cursor. Items are keyed `name_{index}` by
+        # their sequential position, so the source must re-enumerate identically
+        # across replays. The block returns [WorkflowClass, kwargs] (or a class).
+        def spawn_each(name, source, of: 1000)
+          cb = current_branch!
+          validate_step_name_segment!(name)
+          cursor = (cb[:log].metadata&.dig("cursors", name.to_s)) || {}
+          n = (cursor["n"] || 0)
+
+          if source.is_a?(ActiveRecord::Relation)
+            source.find_in_batches(batch_size: of, start: cursor["pk"], error_on_ignore: true) do |records|
+              entries = records.map do |record|
+                klass, kw = normalize_spawn(yield(record))
+                ck = "#{@workflow.key}$#{cb[:name]}$#{name}_#{n}"
+                n += 1
+                [ck, klass, kw]
+              end
+              dispatch_children(cb, entries)
+              advance_cursor!(cb, name, pk: records.last.id, n: n)
+            end
+          else
+            source.drop(n).each_slice(of) do |slice|
+              entries = slice.map do |item|
+                klass, kw = normalize_spawn(yield(item))
+                ck = "#{@workflow.key}$#{cb[:name]}$#{name}_#{n}"
+                n += 1
+                [ck, klass, kw]
+              end
+              dispatch_children(cb, entries)
+              advance_cursor!(cb, name, n: n)
+            end
+          end
+          name
+        end
+```
+
+And the private helper (add near the other privates in `Branch`):
+
+```ruby
+        # Normalize the block return: [Klass, kwargs] or a bare Klass.
+        def normalize_spawn(result)
+          klass, kwargs = Array(result)
+          [klass, kwargs || {}]
+        end
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bundle exec ruby -I test test/spawn_each_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/chrono_forge/executor/methods/branch.rb test/spawn_each_test.rb test/internal/app/jobs/spawn_each_workflow.rb
+git commit -m "feat(branches): spawn_each streaming bulk dispatch with cursor"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/executor/methods/branch.rb", "test/spawn_each_test.rb", "test/internal/app/jobs/spawn_each_workflow.rb"], "verifyCommand": "bundle exec ruby -I test test/spawn_each_test.rb", "acceptanceCriteria": ["one indexed child per item", "class from block honored (mixed)", "raises on conflicting AR order", "cursor persisted"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 5: `BranchMergeJob` — the lightweight poller
+
+**Goal:** Implement the dedicated poller: capped-count probe per branch, wake the parent when all branches are sealed + drained, otherwise re-kick dropped jobs and reschedule with an adaptive (capped-count) interval.
+
+**Files:**
+- Create: `lib/chrono_forge/branch_merge_job.rb`
+- Modify: `lib/chrono_forge/executor.rb` (poll-cadence constants — optional, can live on the job)
+- Create: `test/branch_merge_job_test.rb`
+
+**Acceptance Criteria:**
+- [ ] When every branch log is `completed` (sealed) and has zero incomplete children, the job enqueues the parent workflow (`parent_job_class.perform_later(parent_key)`) and does not reschedule.
+- [ ] Otherwise it reschedules itself with delay `clamp(pending * FACTOR, min, max)` and does not wake the parent.
+- [ ] The pending count is capped at `CAP` (never counts beyond it).
+- [ ] A never-started child (`started_at` nil) older than the re-kick threshold is re-enqueued.
+
+**Verify:** `bundle exec ruby -I test test/branch_merge_job_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests**
+
+Create `test/branch_merge_job_test.rb`:
+
+```ruby
+require "test_helper"
+
+class BranchMergeJobTest < ActiveJob::TestCase
+  def setup
+    @parent = ChronoForge::Workflow.create!(key: "bmj-parent", job_class: "SingleSpawnWorkflow")
+    @log = @parent.execution_logs.create!(step_name: "branch$g", state: :completed)
+  end
+
+  def child!(state:, started_at: Time.current)
+    ChronoForge::Workflow.create!(
+      key: "c-#{SecureRandom.hex}", job_class: "NoopChild",
+      parent_execution_log_id: @log.id, state: state, started_at: started_at
+    )
+  end
+
+  def test_wakes_parent_when_all_complete
+    child!(state: :completed)
+    assert_enqueued_with(job: SingleSpawnWorkflow, args: ["bmj-parent"]) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+
+  def test_reschedules_when_incomplete
+    child!(state: :running)
+    assert_enqueued_with(job: ChronoForge::BranchMergeJob) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+    refute_enqueued_with(job: SingleSpawnWorkflow)
+  end
+
+  def test_rekicks_never_started_child
+    stuck = child!(state: :idle, started_at: nil)
+    stuck.update_column(:updated_at, 10.minutes.ago)
+    assert_enqueued_with(job: NoopChild, args: ["#{stuck.key}"]) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bundle exec ruby -I test test/branch_merge_job_test.rb`
+Expected: FAIL — `NameError: uninitialized constant ChronoForge::BranchMergeJob`.
+
+- [ ] **Step 3: Implement the poller**
+
+Create `lib/chrono_forge/branch_merge_job.rb`:
+
+```ruby
+module ChronoForge
+  # Lightweight poller that joins one or more branches. NOT a workflow — it holds
+  # no lock, does no replay, and carries no context. It exists so the heavy parent
+  # workflow is replayed only twice per merge (kick off + completion wake).
+  class BranchMergeJob < ActiveJob::Base
+    CAP = 5_000          # cap the pending count; beyond it we just pick max_interval
+    FACTOR = 0.06        # seconds of delay per pending child
+    REKICK_AFTER = 5.minutes
+
+    def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+      pending = branch_log_ids.sum { |id| incomplete_scope(id).limit(CAP).count }
+      sealed = branch_log_ids.all? { |id| branch_sealed?(id) }
+
+      if sealed && pending.zero?
+        parent_job_class.constantize.perform_later(parent_key)
+        return
+      end
+
+      rekick_dropped_jobs(branch_log_ids)
+
+      delay = [[pending * FACTOR, min_interval].max, max_interval].min
+      self.class.set(wait: delay.seconds)
+        .perform_later(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+    end
+
+    private
+
+    def incomplete_scope(branch_log_id)
+      Workflow.where(parent_execution_log_id: branch_log_id)
+        .where.not(state: Workflow.states[:completed])
+    end
+
+    def branch_sealed?(branch_log_id)
+      ExecutionLog.where(id: branch_log_id, state: ExecutionLog.states[:completed]).exists?
+    end
+
+    # A child dispatched but never run (its job was dropped by the backend) is
+    # re-enqueued. started_at IS NULL can't distinguish "never enqueued" from
+    # "queued but not yet picked up", so we only re-kick children that have been
+    # idle past REKICK_AFTER. Re-enqueue is idempotent: a completed/running child
+    # no-ops via the executable?/lock guard.
+    def rekick_dropped_jobs(branch_log_ids)
+      branch_log_ids.each do |id|
+        Workflow.where(parent_execution_log_id: id, started_at: nil)
+          .where("updated_at < ?", REKICK_AFTER.ago)
+          .find_each do |child|
+            child.job_klass.perform_later(child.key, **child.kwargs.symbolize_keys)
+          end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bundle exec ruby -I test test/branch_merge_job_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add lib/chrono_forge/branch_merge_job.rb test/branch_merge_job_test.rb
+git commit -m "feat(branches): BranchMergeJob lightweight poller"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/branch_merge_job.rb", "test/branch_merge_job_test.rb"], "verifyCommand": "bundle exec ruby -I test test/branch_merge_job_test.rb", "acceptanceCriteria": ["wakes parent when all complete", "reschedules when incomplete", "capped count", "re-kicks never-started child"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 6: `merge_branches` / `merge_branch` — the join
+
+**Goal:** Implement `merge_branches(*names)` (alias `merge_branch`): immediate done-check, else enqueue `BranchMergeJob` and halt; remove joined branches from `@open_branches` on completion; raise on an unopened name. Provide the shared helpers (`branches_done?`, `enqueue_branch_merge_job`, `open_branch!`) used by the completion gate in Task 7.
+
+**Files:**
+- Modify: `lib/chrono_forge/executor/methods/merge_branches.rb`
+- Create: `test/merge_branches_test.rb`
+- Create: `test/internal/app/jobs/two_branch_workflow.rb`
+
+**Acceptance Criteria:**
+- [ ] After all children of the named branches complete, the parent resumes and the `merge$<names>` log is `completed`.
+- [ ] While children are incomplete, the parent halts (idle) and a `BranchMergeJob` is enqueued.
+- [ ] A failed/stalled child keeps the parent parked (Option A); recovering it lets the merge resolve.
+- [ ] `merge_branches :never_opened` raises `ArgumentError`.
+
+**Verify:** `bundle exec ruby -I test test/merge_branches_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests + fixture**
+
+Create `test/internal/app/jobs/two_branch_workflow.rb`:
+
+```ruby
+class TwoBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :a do
+      spawn :one, NoopChild
+    end
+    branch :b do
+      spawn :two, NoopChild
+    end
+    merge_branches :a, :b
+    durably_execute :finalize
+  end
+
+  private
+
+  def finalize
+    context["finalized"] = true
+  end
+end
+```
+
+Create `test/merge_branches_test.rb`:
+
+```ruby
+require "test_helper"
+
+class MergeBranchesTest < ActiveJob::TestCase
+  def test_parent_resumes_after_branches_complete
+    TwoBranchWorkflow.perform_later("mb-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "mb-1")
+    assert parent.completed?, "parent should complete once both branches merge"
+    assert_equal true, parent.context["finalized"]
+    merge_log = parent.execution_logs.find { |l| l.step_name.start_with?("merge$") }
+    assert merge_log.completed?
+  end
+
+  def test_unopened_branch_name_raises
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform = merge_branches(:nope)
+    end
+    Object.const_set(:NoBranchMergeWorkflow, job)
+    NoBranchMergeWorkflow.perform_later("nb-1")
+    assert_raises(ArgumentError) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :NoBranchMergeWorkflow) if defined?(NoBranchMergeWorkflow)
+  end
+
+  # Option A: a non-completed (stalled) child keeps the parent parked; recovering
+  # the child lets the merge resolve.
+  def test_failed_child_parks_parent_until_recovered
+    StalledChildBranchWorkflow.perform_later("oa-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "oa-1")
+    child = ChronoForge::Workflow.find_by(key: "oa-1$grp$c")
+    refute parent.completed?, "parent must stay parked while child is not completed"
+    assert child.stalled?, "child should be stalled (permanent failure)"
+
+    # Recover the child; drive jobs again — the merge poll should now resolve.
+    child.context # no-op touch
+    child.update!(state: :idle) # simulate fix + allow re-run
+    StalledChildBranchWorkflow::ALLOW_COMPLETE[:ok] = true
+    child.retry_later rescue child.job_klass.perform_later(child.key)
+    perform_all_jobs
+
+    assert ChronoForge::Workflow.find_by(key: "oa-1").completed?,
+      "parent should complete once the recovered child completes"
+  end
+end
+```
+
+And add the stalling fixture `test/internal/app/jobs/stalled_child_branch_workflow.rb`:
+
+```ruby
+class StalledChildBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  # Toggled by the test to let the child succeed on recovery.
+  ALLOW_COMPLETE = {ok: false}
+
+  def perform
+    branch :grp do
+      spawn :c, StalledChild
+    end
+    merge_branches :grp
+  end
+end
+
+class StalledChild < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(**)
+    durably_execute :maybe_fail, retry_policy: ChronoForge::Executor::RetryPolicy.new(retry_on: [])
+  end
+
+  private
+
+  def maybe_fail
+    raise "not yet" unless StalledChildBranchWorkflow::ALLOW_COMPLETE[:ok]
+  end
+end
+```
+
+> The exact recovery mechanics (`retry_later` vs re-enqueue, the `ALLOW_COMPLETE` toggle) may need adjusting against the real stall/retry behaviour observed in `test/chrono_forge_test.rb`'s permanent-failure tests — the assertion that matters is **parent parked while child not completed, parent completes after child completes**. Mirror the permanent-failure pattern already used in `chrono_forge_test.rb` for the stall setup.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bundle exec ruby -I test test/merge_branches_test.rb`
+Expected: FAIL — `NoMethodError: merge_branches`.
+
+- [ ] **Step 3: Implement `merge_branches` + helpers**
+
+Replace the placeholder `lib/chrono_forge/executor/methods/merge_branches.rb` with:
+
+```ruby
+module ChronoForge
+  module Executor
+    module Methods
+      module MergeBranches
+        # Join one or more named branches. Separate from dispatch so branches run
+        # concurrently. Does one immediate check; if not done, hands off to the
+        # lightweight BranchMergeJob and halts (the heavy parent is not replayed
+        # per poll). Default cadence clamps between min/max, scaled by pending.
+        def merge_branches(*names, min_interval: 5.seconds, max_interval: 5.minutes)
+          step_name = "merge$#{names.map(&:to_s).sort.join(",")}"
+          log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }
+          return if log.completed?
+
+          branch_log_ids = names.map { |nm| open_branch!(nm)[:log_id] }
+
+          if branches_done?(branch_log_ids)
+            names.each { |nm| @open_branches.delete(nm.to_s) }
+            log.update!(state: :completed, completed_at: Time.current)
+            return
+          end
+
+          enqueue_branch_merge_job(branch_log_ids, min_interval, max_interval)
+          halt_execution!
+        end
+        alias_method :merge_branch, :merge_branches
+
+        private
+
+        def open_branch!(name)
+          (@open_branches || {}).fetch(name.to_s) do
+            raise ArgumentError, "no open branch named #{name.inspect} (open it with `branch #{name.inspect} do … end` first)"
+          end
+        end
+
+        # A branch is done when its log is sealed (completed) and it has no
+        # incomplete children. exists? short-circuits at the first incomplete row.
+        def branches_done?(branch_log_ids)
+          branch_log_ids.all? do |id|
+            next false unless ExecutionLog.where(id: id, state: ExecutionLog.states[:completed]).exists?
+            !Workflow.where(parent_execution_log_id: id)
+              .where.not(state: Workflow.states[:completed]).exists?
+          end
+        end
+
+        def enqueue_branch_merge_job(branch_log_ids, min_interval, max_interval)
+          BranchMergeJob.perform_later(
+            @workflow.key, self.class.to_s, branch_log_ids,
+            min_interval.to_i, max_interval.to_i
+          )
+        end
+      end
+    end
+  end
+end
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bundle exec ruby -I test test/merge_branches_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite to catch regressions**
+
+Run: `bundle exec rake test`
+Expected: all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/chrono_forge/executor/methods/merge_branches.rb test/merge_branches_test.rb test/internal/app/jobs/two_branch_workflow.rb
+git commit -m "feat(branches): merge_branches poll-join"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/executor/methods/merge_branches.rb", "test/merge_branches_test.rb", "test/internal/app/jobs/two_branch_workflow.rb"], "verifyCommand": "bundle exec ruby -I test test/merge_branches_test.rb", "acceptanceCriteria": ["parent resumes after branches complete", "halts + enqueues poller while incomplete", "unopened name raises"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 7: Completion gate — automerge + raise on unmerged
+
+**Goal:** In `complete_workflow!`, before sealing, inspect `@open_branches`: raise `UnmergedBranchError` for any leftover non-automerge branch; for leftover automerge branches, join them (poll/halt) before completing.
+
+**Files:**
+- Modify: `lib/chrono_forge/executor/methods/workflow_states.rb`
+- Create: `test/automerge_test.rb`
+
+**Acceptance Criteria:**
+- [ ] An `automerge: true` branch with no `merge_branches` blocks workflow completion until its children finish, then completes.
+- [ ] A branch opened with neither `merge_branches` nor `automerge: true` raises `UnmergedBranchError` at completion (even if its children already finished).
+- [ ] A branch already joined via `merge_branches` does not re-trigger at the gate.
+
+**Verify:** `bundle exec ruby -I test test/automerge_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write failing tests + fixture**
+
+Create `test/internal/app/jobs/unmerged_branch_workflow.rb`:
+
+```ruby
+class UnmergedBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :forgotten do            # no automerge, never merged
+      spawn :c, NoopChild
+    end
+  end
+end
+```
+
+Create `test/automerge_test.rb`:
+
+```ruby
+require "test_helper"
+
+class AutomergeTest < ActiveJob::TestCase
+  # SingleSpawnWorkflow opens branch :grp with automerge: true and no merge.
+  def test_automerge_blocks_completion_until_children_done
+    SingleSpawnWorkflow.perform_later("am-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "am-1")
+    assert parent.completed?, "automerge branch should be joined before completion"
+    child = ChronoForge::Workflow.find_by(key: "am-1$grp$child")
+    assert child.completed?
+  end
+
+  def test_unmerged_branch_raises
+    UnmergedBranchWorkflow.perform_later("um-1")
+    error = assert_raises(ChronoForge::Executor::UnmergedBranchError) { perform_all_jobs }
+    assert_match(/forgotten/, error.message)
+  end
+end
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `bundle exec ruby -I test test/automerge_test.rb`
+Expected: `test_unmerged_branch_raises` FAILS (no error raised — branch silently detached).
+
+- [ ] **Step 3: Add the completion gate**
+
+In `lib/chrono_forge/executor/methods/workflow_states.rb`, change the start of `complete_workflow!` to call the gate first:
+
+```ruby
+        def complete_workflow!
+          enforce_branch_joins!
+
+          # Create an execution log for workflow completion
+          execution_log = find_or_create_execution_log!("$workflow_completion$") do |log|
+            log.started_at = Time.current
+          end
+          # ... unchanged body ...
+```
+
+Add the private gate method to the `WorkflowStates` module (it uses `branches_done?` / `enqueue_branch_merge_job` from `MergeBranches`, available on the same instance):
+
+```ruby
+        # Every branch must be joined — explicitly (merge_branches) or implicitly
+        # (automerge: true). @open_branches is the in-memory registry rebuilt each
+        # replay pass: branch adds, merge_branches removes on completion. Anything
+        # left here is either an automerge branch to join, or a forgotten join.
+        def enforce_branch_joins!
+          open = @open_branches || {}
+          return if open.empty?
+
+          unmerged = open.reject { |_, b| b[:automerge] }
+          if unmerged.any?
+            names = unmerged.keys
+            raise UnmergedBranchError,
+              "branch(es) #{names.join(", ")} were opened but never merged. " \
+              "Add `merge_branches #{names.map { |n| ":#{n}" }.join(", ")}` " \
+              "or open with `branch(..., automerge: true)`."
+          end
+
+          auto_ids = open.values.map { |b| b[:log_id] }
+          unless branches_done?(auto_ids)
+            enqueue_branch_merge_job(auto_ids, 5.seconds, 5.minutes)
+            halt_execution!   # poller wakes the parent; the gate re-runs on replay
+          end
+        end
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `bundle exec ruby -I test test/automerge_test.rb`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Run: `bundle exec rake test`
+Expected: all green (confirm KitchenSink etc. — which open no branches — are unaffected; `enforce_branch_joins!` returns early when `@open_branches` is empty).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add lib/chrono_forge/executor/methods/workflow_states.rb test/automerge_test.rb test/internal/app/jobs/unmerged_branch_workflow.rb
+git commit -m "feat(branches): completion gate — automerge + raise on unmerged"
+```
+
+```json:metadata
+{"files": ["lib/chrono_forge/executor/methods/workflow_states.rb", "test/automerge_test.rb", "test/internal/app/jobs/unmerged_branch_workflow.rb"], "verifyCommand": "bundle exec ruby -I test test/automerge_test.rb", "acceptanceCriteria": ["automerge blocks completion until children done", "unmerged branch raises", "already-merged branch is a no-op at gate"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 8: Crash-recovery (cursor resume) + scale/perf regression tests
+
+**Goal:** Prove dispatch resumes from the cursor after a mid-dispatch crash (no duplicate children, bounded rework), and that dispatch is `⌈N/of⌉` inserts (not N) with constant per-item work.
+
+**Files:**
+- Create: `test/branch_recovery_test.rb`
+- Create: `test/branch_scale_test.rb`
+
+**Acceptance Criteria:**
+- [ ] A crash after chunk *k* leaves `metadata.cursors[name]` at that point; the resumed run continues from it, ends with exactly N children, no duplicate keys.
+- [ ] Dispatching N children with batch size `of` issues `⌈N/of⌉` `INSERT INTO chrono_forge_workflows` statements (not N).
+
+**Verify:** `bundle exec ruby -I test test/branch_recovery_test.rb test/branch_scale_test.rb` → PASS
+
+**Steps:**
+
+- [ ] **Step 1: Write the scale test**
+
+Create `test/branch_scale_test.rb`:
+
+```ruby
+require "test_helper"
+
+class BranchScaleTest < ActiveJob::TestCase
+  def setup
+    User.delete_all
+    25.times { |i| User.create!(name: "u#{i}", email: "u#{i}@e.com") }
+  end
+
+  def test_dispatch_uses_bulk_inserts_not_one_per_child
+    inserts = 0
+    pattern = /INSERT INTO ["`]?chrono_forge_workflows/i
+    sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*a|
+      inserts += 1 if pattern.match?(a.last[:sql].to_s)
+    end
+    # of: 10 over 25 users => ceil(25/10) = 3 insert_all statements.
+    SpawnEachWorkflow.perform_later("scale-1", of: 10)
+    perform_all_jobs_before(1.second) # dispatch happens on the first pass
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    branch_log = ChronoForge::Workflow.find_by(key: "scale-1").execution_logs.find_by(step_name: "branch$grp")
+    assert_equal 25, ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).count
+    assert_operator inserts, :<=, 3, "expected <= ceil(25/10) bulk inserts, got #{inserts}"
+  end
+end
+```
+
+> Note: this asserts on **`insert_all`** (DB rows), which is always bulk. Do NOT assert bulk job *enqueue* — under the test adapter `perform_all_later` falls back to per-job enqueue.
+
+- [ ] **Step 2: Write the recovery test**
+
+Create `test/branch_recovery_test.rb`:
+
+```ruby
+require "test_helper"
+
+class BranchRecoveryTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    User.delete_all
+    25.times { |i| User.create!(name: "u#{i}", email: "u#{i}@e.com") }
+  end
+
+  def test_resumes_dispatch_from_cursor_after_glitch
+    # Glitch once during dispatch; ChaoticJob re-runs the workflow, which must
+    # resume spawn_each from the persisted cursor rather than restarting at 0.
+    workflow = SpawnEachWorkflow.new("rec-1", of: 10)
+    run_scenario(workflow, glitch: ["before", "#{ChronoForge::Executor::Methods::Branch.instance_method(:dispatch_children).source_location[0]}:#{dispatch_children_line}"])
+
+    branch_log = ChronoForge::Workflow.find_by(key: "rec-1").execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+    assert_equal 25, children.count, "exactly N children, no duplicates after resume"
+    assert_equal 25, children.distinct.count(:key)
+  end
+
+  private
+
+  # Resolve the line of the perform_all_later call inside dispatch_children so the
+  # glitch lands mid-dispatch. Adjust if the method changes.
+  def dispatch_children_line
+    src = File.read(ChronoForge::Executor::Methods::Branch.instance_method(:dispatch_children).source_location[0])
+    src.lines.index { |l| l.include?("perform_all_later") }.to_i + 1
+  end
+end
+```
+
+> If targeting an exact glitch line proves brittle, an acceptable alternative is to call `SpawnEachWorkflow.perform_later` twice in a row with the same key (simulating a re-run) after manually truncating `metadata.cursors` to a mid-point, and assert the final child set is exactly N with no duplicates. Either approach proves cursor-resume idempotency.
+
+- [ ] **Step 3: Run both to verify they fail, then pass**
+
+Run: `bundle exec ruby -I test test/branch_scale_test.rb test/branch_recovery_test.rb`
+Expected: PASS (these exercise Task 3/4 code; if they fail, fix the dispatch/cursor logic, not the tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/branch_recovery_test.rb test/branch_scale_test.rb
+git commit -m "test(branches): cursor-resume recovery + bulk-dispatch scale guards"
+```
+
+```json:metadata
+{"files": ["test/branch_recovery_test.rb", "test/branch_scale_test.rb"], "verifyCommand": "bundle exec ruby -I test test/branch_scale_test.rb test/branch_recovery_test.rb", "acceptanceCriteria": ["cursor resume: exactly N children no dupes", "dispatch uses ceil(N/of) bulk inserts"], "requiresUserVerification": false}
+```
+
+---
+
+### Task 9: Dependency floor + README
+
+**Goal:** Pin `activejob >= 7.1` (required for `perform_all_later`) and document the feature with the load-bearing caveats.
+
+**Files:**
+- Modify: `chrono_forge.gemspec`
+- Modify: `README.md`
+
+**Acceptance Criteria:**
+- [ ] `chrono_forge.gemspec` requires `activejob >= 7.1`.
+- [ ] README has a "Branches" section documenting `branch`/`spawn`/`spawn_each`/`merge_branches`/`automerge` and the three caveats (every branch must be joined; parent not replayed per poll; source must be stable during dispatch).
+
+**Verify:** `bundle exec ruby -e "require 'rubygems'; spec = Gem::Specification.load('chrono_forge.gemspec'); dep = spec.dependencies.find { |d| d.name == 'activejob' }; abort('no floor') unless dep.requirement.satisfied_by?(Gem::Version.new('7.1')) && !dep.requirement.satisfied_by?(Gem::Version.new('7.0')); puts 'ok'"` → `ok`
+
+**Steps:**
+
+- [ ] **Step 1: Pin the dependency**
+
+In `chrono_forge.gemspec`, change:
+
+```ruby
+  spec.add_dependency "activejob"
+```
+
+to:
+
+```ruby
+  spec.add_dependency "activejob", ">= 7.1"
+```
+
+- [ ] **Step 2: Document in README**
+
+Add a "Branches: parallel sub-workflows" section to `README.md` with a worked example (the `branch :fulfillment, automerge: true do … end` + `merge_branches` example from the spec's Goal section) and a "Caveats" callout covering, verbatim in spirit:
+- Every branch must be merged or `automerge: true`, else `UnmergedBranchError`.
+- The heavy parent is not replayed per poll — a lightweight `BranchMergeJob` does the waiting.
+- The source must be stable during a branch's dispatch window (items keyed `name_{index}` by position; `error_on_ignore: true` catches ordering, not insertion).
+
+- [ ] **Step 3: Verify the gemspec floor**
+
+Run the Verify command above. Expected: `ok`.
+
+- [ ] **Step 4: Run the full suite one last time**
+
+Run: `bundle exec rake test`
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add chrono_forge.gemspec README.md
+git commit -m "feat(branches): require activejob >= 7.1; document branches"
+```
+
+```json:metadata
+{"files": ["chrono_forge.gemspec", "README.md"], "verifyCommand": "bundle exec rake test", "acceptanceCriteria": ["activejob >= 7.1 floor", "README branches section + caveats"], "requiresUserVerification": false}
+```
+
+---
+
+## Notes for the implementer
+
+- **Zeitwerk loading:** new files under `lib/chrono_forge/` autoload by namespace — `branch_merge_job.rb` → `ChronoForge::BranchMergeJob`; `executor/methods/branch.rb` → `ChronoForge::Executor::Methods::Branch`. No manual `require`. The only wiring is the `include`s in `executor/methods.rb`.
+- **Helper visibility:** `branch.rb`, `merge_branches.rb`, and `workflow_states.rb` are all mixed into the same `Executor` instance, so their private helpers (`dispatch_children`, `branches_done?`, `enqueue_branch_merge_job`, `current_branch!`) call each other freely.
+- **`insert_all` + JSON:** pass `kwargs`/`options`/`context` as Ruby hashes; Rails casts them to the json/jsonb columns. `insert_all` does not set timestamps — `created_at`/`updated_at` are set explicitly in `dispatch_children`.
+- **Child execution on first run:** `dispatch_children` pre-inserts the child row (with `kwargs`), then enqueues `klass.new(child_key, **kwargs)`. When the child job runs, the executor's `setup_workflow!` finds the pre-inserted row and uses its stored `kwargs` — the job-arg kwargs are redundant but harmless.
+- **Run order:** Tasks 1→2→3→4 are strictly sequential; 5 depends on 2; 6 depends on 5 and 3; 7 depends on 6 and 3/4; 8 depends on 7; 9 is independent. The `MergeBranches` module must exist (even empty) once Task 3 wires the include — create the file in Task 3, flesh it out in Task 6.

--- a/docs/superpowers/plans/2026-06-26-branches-spawn-merge.md.tasks.json
+++ b/docs/superpowers/plans/2026-06-26-branches-spawn-merge.md.tasks.json
@@ -1,0 +1,67 @@
+{
+  "planPath": "docs/superpowers/plans/2026-06-26-branches-spawn-merge.md",
+  "tasks": [
+    {
+      "id": 1,
+      "subject": "Task 1: Schema — parent_execution_log_id column + index",
+      "status": "completed",
+      "description": "Add nullable parent_execution_log_id (FK type matching pk) to chrono_forge_workflows + composite (parent_execution_log_id, state) index, via an additive migration wired into the generators and applied to the test DB.\n\n```json:metadata\n{\"files\": [\"lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb\", \"lib/generators/chrono_forge/migration_actions.rb\", \"test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb\", \"test/schema_test.rb\", \"test/generators_test.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/schema_test.rb\", \"acceptanceCriteria\": [\"parent_execution_log_id column exists\", \"(parent_execution_log_id, state) index exists\", \"migration in MIGRATIONS + generators_test\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 2,
+      "subject": "Task 2: Model associations",
+      "status": "completed",
+      "blockedBy": [1],
+      "description": "Workflow belongs_to :parent_execution_log (optional); ExecutionLog has_many :spawned_workflows (fk parent_execution_log_id, dependent: :nullify).\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/workflow.rb\", \"lib/chrono_forge/execution_log.rb\", \"test/branch_associations_test.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/branch_associations_test.rb\", \"acceptanceCriteria\": [\"parent_execution_log association\", \"spawned_workflows association\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 3,
+      "subject": "Task 3: branch block + spawn (single)",
+      "status": "completed",
+      "blockedBy": [2],
+      "description": "branch(name, automerge:) durable step with in-memory @open_branches registry, eager dispatch, seal-on-close, SKIP-BLOCK-WHEN-SEALED. spawn(name, klass, **kwargs) single child. spawn outside branch raises NotInBranchError. Error classes + Methods include (create empty MergeBranches stub).\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/executor/methods/branch.rb\", \"lib/chrono_forge/executor.rb\", \"lib/chrono_forge/executor/methods.rb\", \"lib/chrono_forge/executor/methods/merge_branches.rb\", \"test/branch_test.rb\", \"test/internal/app/jobs/noop_child.rb\", \"test/internal/app/jobs/single_spawn_workflow.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/branch_test.rb\", \"acceptanceCriteria\": [\"spawn creates linked child + seals branch\", \"spawn outside branch raises\", \"sealed branch skips block on replay\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 4,
+      "subject": "Task 4: spawn_each streaming dispatch",
+      "status": "completed",
+      "blockedBy": [3],
+      "description": "spawn_each(name, source, of:) — AR keyset (find_in_batches start:, error_on_ignore: true) or enumerable (offset/drop), one child per item keyed name_{index}, class from block, cursor {pk,n} on branch log metadata.\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/executor/methods/branch.rb\", \"test/spawn_each_test.rb\", \"test/internal/app/jobs/spawn_each_workflow.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/spawn_each_test.rb\", \"acceptanceCriteria\": [\"one indexed child per item\", \"class from block (mixed)\", \"raises on conflicting AR order\", \"cursor persisted\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 5,
+      "subject": "Task 5: BranchMergeJob poller",
+      "status": "completed",
+      "blockedBy": [2],
+      "description": "ChronoForge::BranchMergeJob (plain ActiveJob): capped-count probe per branch (limit CAP), wake parent when all sealed + pending 0, else re-kick never-started children (started_at nil older than REKICK_AFTER) and reschedule clamp(pending*FACTOR, min, max).\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/branch_merge_job.rb\", \"test/branch_merge_job_test.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/branch_merge_job_test.rb\", \"acceptanceCriteria\": [\"wakes parent when complete\", \"reschedules when incomplete\", \"capped count\", \"re-kicks never-started child\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 6,
+      "subject": "Task 6: merge_branches / merge_branch join",
+      "status": "completed",
+      "blockedBy": [3, 5],
+      "description": "merge_branches(*names, min_interval:, max_interval:) + alias merge_branch — immediate done-check, else enqueue BranchMergeJob + halt; remove joined names from @open_branches on completion; raise ArgumentError for unopened name. Shared helpers branches_done?/enqueue_branch_merge_job/open_branch!.\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/executor/methods/merge_branches.rb\", \"test/merge_branches_test.rb\", \"test/internal/app/jobs/two_branch_workflow.rb\", \"test/internal/app/jobs/stalled_child_branch_workflow.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/merge_branches_test.rb\", \"acceptanceCriteria\": [\"parent resumes after branches complete\", \"halts+enqueues poller while incomplete\", \"unopened name raises\", \"Option A: stalled child parks parent until recovered\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 7,
+      "subject": "Task 7: Completion gate — automerge + raise on unmerged",
+      "status": "completed",
+      "blockedBy": [4, 6],
+      "description": "enforce_branch_joins! at start of complete_workflow!: raise UnmergedBranchError for leftover non-automerge branches; for leftover automerge branches not done, enqueue BranchMergeJob + halt; else seal. Early-return when @open_branches empty.\n\n```json:metadata\n{\"files\": [\"lib/chrono_forge/executor/methods/workflow_states.rb\", \"test/automerge_test.rb\", \"test/internal/app/jobs/unmerged_branch_workflow.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/automerge_test.rb\", \"acceptanceCriteria\": [\"automerge blocks completion until children done\", \"unmerged branch raises\", \"already-merged branch no-op at gate\", \"empty @open_branches early-returns\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 8,
+      "subject": "Task 8: Crash-recovery + scale regression tests",
+      "status": "completed",
+      "blockedBy": [7],
+      "description": "Prove cursor-resume (glitch mid-dispatch -> resume from metadata.cursors, exactly N children, no dupes) and bulk dispatch (insert_all issues ceil(N/of) INSERTs, not N). Do NOT assert bulk enqueue (test adapter falls back to per-job).\n\n```json:metadata\n{\"files\": [\"test/branch_recovery_test.rb\", \"test/branch_scale_test.rb\"], \"verifyCommand\": \"bundle exec ruby -I test test/branch_scale_test.rb test/branch_recovery_test.rb\", \"acceptanceCriteria\": [\"cursor resume: exactly N children, no dupes\", \"dispatch uses ceil(N/of) bulk inserts\"], \"requiresUserVerification\": false}\n```"
+    },
+    {
+      "id": 9,
+      "subject": "Task 9: activejob >= 7.1 floor + README",
+      "status": "completed",
+      "description": "Pin activejob >= 7.1 (perform_all_later) in gemspec; document Branches in README with worked example + 3 caveats (every branch joined or UnmergedBranchError; parent not replayed per poll; source stable during dispatch).\n\n```json:metadata\n{\"files\": [\"chrono_forge.gemspec\", \"README.md\"], \"verifyCommand\": \"bundle exec rake test\", \"acceptanceCriteria\": [\"activejob >= 7.1 floor\", \"README branches section + caveats\"], \"requiresUserVerification\": false}\n```"
+    }
+  ],
+  "lastUpdated": "2026-06-26T00:00:00Z"
+}

--- a/docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md
+++ b/docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md
@@ -1,43 +1,7 @@
 # Branches — Concurrent Sub-Workflows (`branch` / `spawn` / `merge_branches`) — Design
 
 **Date:** 2026-06-25
-**Status:** Implemented (`feat/branches`). See "Implementation deltas" below for where
-the shipped behavior refined this design during the build.
-
-> ## Implementation deltas (as shipped — these override the body below)
->
-> The feature was built and reviewed task-by-task; a few decisions were refined mid-build
-> and the shipped code is the source of truth where it differs from this document:
->
-> 1. **Automerge joins INLINE at the branch block's close**, not deferred to a workflow
->    completion gate. `branch(name, automerge: true)` ≡ eager dispatch inside the block
->    followed immediately by `merge_branches(name)` — execution does not continue past the
->    block until the branch's children complete. (The "Completion gate — automerge" section
->    below describes the abandoned deferred design.) The completion gate now does only the
->    **unmerged-raise** check: any branch left in `@open_branches` at completion (i.e.
->    opened but neither `merge_branches`-d nor automerged) raises `UnmergedBranchError`.
-> 2. **`merge_branches` of an unopened name raises `UnknownBranchError`** (a
->    `NotExecutableError` subclass), not `ArgumentError` — so it fail-fasts via the existing
->    rescue without broadening the executor. `merge_branches` also validates each name
->    (`$` and `,` are rejected — `,` is the merge step-name separator).
-> 3. **AR `spawn_each` children are keyed by record primary key** (`name_<record.id>`), not
->    a sequential index. `find_in_batches(start:)` is inclusive, so a crash-resume re-yields
->    the boundary record under the SAME key and `insert_all`-ignore dedups it (idempotent).
->    Plain (non-AR) enumerables keep `name_<index>` + `drop(n)` (exclusive, already safe).
-> 4. **An explicit `.order` on an AR source raises** (iteration is by PK); `spawn_each`
->    checks `order_values.present?` up front rather than relying on `find_in_batches`'s
->    `error_on_ignore`.
-> 5. **Dispatch is queue-idempotent:** after `insert_all`, only children still `:idle` are
->    enqueued, so a crash-resume never re-runs an already-completed/running child.
-> 6. **The dropped-job re-kick filters by `state: :idle`**, not `started_at IS NULL` —
->    branch children are pre-inserted and never get `started_at` set, so `:idle` is the
->    correct "never picked up" signal. The re-kick is batch-capped.
-> 7. **`merge/automerge state is in-memory only** (`@open_branches`), rebuilt each replay
->    pass — no persisted `merged`/`automerge` flags (as the body already states).
->
-> Everything else in this document matches the implementation.
-
-**Original status:** Draft (pending spec review)
+**Status:** Implemented (branch `feat/branches`).
 **Scope:** New public API, additive. Introduces parent/child workflows and a
 fan-out/fan-in primitive built to dispatch **hundreds of thousands** of children per
 branch. One new (generic, reusable) column on `chrono_forge_workflows`; reuses the
@@ -68,8 +32,9 @@ block**. The model mirrors git: you branch, then you merge.
 - `spawn(name, WorkflowClass, **kwargs)` — inside a branch: dispatch a **single** named
   child.
 - `spawn_each(name, source, of:) { |item| [WorkflowClass, kwargs] }` — inside a branch:
-  dispatch **one child per item**, streamed like ActiveRecord batch loading; items are
-  keyed `name_{index}` (sequential index across the stream).
+  dispatch **one child per item**, streamed like ActiveRecord batch loading; AR items are
+  keyed `name_<record.id>` (primary key); plain enumerables are keyed `name_{index}`
+  (sequential index).
 - `merge_branches(*names)` — the **separate** join: halt until every named branch is
   sealed **and** all its children have completed.
 
@@ -77,7 +42,7 @@ block**. The model mirrors git: you branch, then you merge.
 def perform(cycle_id:)
   branch :fulfillment, automerge: true do        # the step; seals when the block closes
     spawn :reconcile, ReconcileWorkflow, region: "EU"   # single child of :fulfillment
-    spawn_each :orders, Order.pending do |order|        # bulk, streamed; keys orders_0, orders_1…
+    spawn_each :orders, Order.pending do |order|        # bulk, streamed; keys orders_<id>…
       order.priority? ? [PriorityOrderWorkflow, { order_id: order.id }]
                       : [OrderWorkflow, { order_id: order.id }]
     end
@@ -105,18 +70,18 @@ end
 | Dispatch timing | **Eager.** Spawns insert + enqueue as the block runs; children start at once. The branch **seals** (log → `completed`) when the block closes. |
 | Join | **Separate `merge_branches`** so branches run concurrently and work can happen in between. Joins one or more named branches at once (`merge_branches :a` for one). |
 | `merge_branch` alias | **Ship a singular `merge_branch(name, **opts)` alias** that delegates to `merge_branches` — reads naturally for the common one-branch case (`merge_branch :a`) without a plural-method/singular-arg mismatch. Decided, not just mentioned. |
-| Automerge | A property **of the branch**: `branch(name, automerge: true)`. When `true`, the branch is auto-joined just before workflow completion (an implicit final merge), so no explicit `merge_branches` is needed. |
+| Automerge | A property **of the branch**: `branch(name, automerge: true)`. When `true`, `branch` eagerly dispatches inside the block and then immediately calls `merge_branches(name)` at the block's close — execution does not continue past the block until the branch's children complete. No explicit `merge_branches` is needed. |
 | Branch tracking | An **in-memory registry** (`@open_branches`), rebuilt each replay pass: `branch` adds, `merge_branches` removes on completion, the completion gate inspects the remainder. Deterministic replay makes it exact — no persisted `merged`/`automerge` flags. |
-| Every branch must be joined | **No detached branches.** A branch left in `@open_branches` at completion with `automerge: false` **raises `UnmergedBranchError`** (fail-fast on a forgotten join), rather than silently letting children run orphaned. |
-| Spawn identity | Spawns are **named** (`spawn :reconcile, …`, `spawn_each :orders, …`). The name anchors the child key and the per-`spawn_each` cursor — stable across code reordering (unlike a positional ordinal). A `spawn_each`'s items are keyed `name_{index}` (sequential index across the stream). |
+| Every branch must be joined | **No detached branches.** Any branch remaining in `@open_branches` at completion (neither `merge_branches`-d nor automerged) **raises `UnmergedBranchError`** (fail-fast on a forgotten join), rather than silently letting children run orphaned. `automerge: true` branches are joined inline at the block close and are absent from `@open_branches` by the time the completion gate runs. |
+| Spawn identity | Spawns are **named** (`spawn :reconcile, …`, `spawn_each :orders, …`). The name anchors the child key and the per-`spawn_each` cursor — stable across code reordering (unlike a positional ordinal). AR items are keyed `name_<record.id>` (primary key); plain enumerable items are keyed `name_{index}` (sequential index). |
 | Bulk source | `spawn_each` **streams** the source — `in_batches(of:, start: cursor)` for AR — never materialising the batch in memory. Scales to millions. |
 | Child class | **Returned from the block** (`[WorkflowClass, kwargs]`); one branch may fan out into mixed workflow types. |
-| Child key | Deterministic: `spawn` → `"#{parent.key}$#{branch}$#{spawn_name}"`; `spawn_each` item → `"#{parent.key}$#{branch}$#{spawn_name}_#{index}"`. Idempotency falls out of the unique-key constraint. |
+| Child key | Deterministic: `spawn` → `"#{parent.key}$#{branch}$#{spawn_name}"`; AR `spawn_each` item → `"#{parent.key}$#{branch}$#{spawn_name}_#{record.id}"`; enumerable item → `"#{parent.key}$#{branch}$#{spawn_name}_#{index}"`. Idempotency falls out of the unique-key constraint. |
 | Cursor | Per `spawn_each`, stored in the `branch$<name>` log's `metadata` keyed by **spawn name** as `{ pk: <keyset>, n: <count/index> }`; persisted **once per dispatched chunk** (bundled with that chunk's `insert_all`). |
 | Completion | **Poll**, no counter: a branch is done when sealed and has no incomplete children (`branch_log.spawned_workflows.where.not(state: :completed)` empty — read as an O(CAP) capped count). Zero per-completion contention. |
 | Poll mechanism | A dedicated lightweight `ChronoForge::BranchMergeJob` (plain ActiveJob — no lock/replay/context) does the repeated probing and wakes the parent only at completion. The heavy parent runs just twice per merge (kick off + wake). No separate recovery timer. |
 | Poll cadence | **Adaptive, capped-count.** `pending = incomplete.limit(CAP).count` (**O(CAP)**, never O(N)); next delay `clamp(pending * factor, min_interval, max_interval)` — fast when few remain, slow when many. |
-| Determinism | Items are keyed by **sequential index**, so the stream must re-enumerate identically across replays. AR sources iterate by PK keyset with `error_on_ignore: true` (a conflicting `.order` **raises**); the index is a running counter alongside the keyset. Non-AR enumerables must re-enumerate deterministically (documented contract). |
+| Determinism | AR items are keyed by **primary key**, so the stream is stable by construction. `spawn_each` rejects an AR relation carrying an explicit `.order` by checking `order_values.present?` up front (raises `NotExecutableError`). Plain enumerable items are keyed by **sequential index** and must re-enumerate deterministically (documented contract). |
 | Failure semantics | **Option A.** A `stalled`/`failed` child keeps the branch incomplete; the parent stays parked; the user recovers the child (`retry_now`/`retry_later`) and the merge then resolves. No new failure states, no cascade. |
 | Nesting | **Free.** A child is a workflow and may open its own branches; the tree forms via `parent_execution_log_id` (child → branch log → parent workflow). |
 
@@ -197,8 +162,11 @@ dispatch cursors; `automerge`/merge state is in-memory, not seeded here):
    directly above the skip path in the implementation.)*
 2. **Pending / new** → set the current-branch context, **yield the block** (named spawns
    dispatch into this branch, advancing their cursors — see below), clear the context,
-   mark the `branch$<name>` log `completed` (**sealed**), and **return** (do not halt —
-   branches are concurrent; the join is separate).
+   mark the `branch$<name>` log `completed` (**sealed**). If `automerge: true`, immediately
+   call `merge_branches(name)` — **execution does not continue past the block** until the
+   branch's children complete (identical to an explicit `merge_branches` call placed right
+   after the block, but guaranteed by the method). Otherwise **return** without halting —
+   branches are concurrent; the explicit join is separate.
 
 Either way, `branch` **registers the branch in the in-memory registry**
 `@open_branches[name] = { automerge:, log_id: }` — this runs on *every* pass (sealed or
@@ -212,27 +180,34 @@ not), since the `branch` method itself always executes even when its block is sk
 - **`spawn(name, klass, **kwargs)`** → one child, key `"#{parent.key}$#{branch}$#{name}"`,
   `job_class: klass.name`, `parent_execution_log_id: branch_log.id`. Idempotent on the key.
 - **`spawn_each(name, source, of:)`** → stream, resuming from `metadata.cursors[name]`
-  (`{ pk:, n: }`); `n` is the running item index:
-  - **AR relation:** `source.in_batches(of:, start: cursor.pk, error_on_ignore: true)`. Per
-    batch, for each record (index `i = n, n+1, …`): `klass, kw = yield(record)`; build child
-    rows (key `"#{parent.key}$#{branch}$#{name}_#{i}"`, `job_class`, `kwargs`,
-    `parent_execution_log_id: branch_log.id`, `state: :idle`); `insert_all(…, unique_by: :key)`
-    (on-conflict-ignore); build the child **job instances** (`klass.new(child_key, **kw)`,
-    validating String key / no reserved kwargs — `perform_all_later` bypasses the class
-    `perform_later` guard) and `ActiveJob.perform_all_later(jobs)`; advance `metadata.cursors[name]` to
-    `{ pk: batch.last.id, n: i+1 }` (committed with the inserts).
-  - **Enumerable:** resume via `drop(n)`; same per-chunk insert/enqueue/advance (`n` only).
+  (`{ pk:, n: }`); `n` is a running count (AR) or the resume index (enumerable):
+  - **AR relation:** rejects `source` if `source.order_values.present?` (raises
+    `NotExecutableError` — iteration is by PK and an explicit order conflicts). Resumes via
+    `source.in_batches(of:, start: cursor.pk)`. Per batch, for each record: `klass, kw =
+    yield(record)`; build child rows (key
+    `"#{parent.key}$#{branch}$#{name}_#{record.id}"`, `job_class`, `kwargs`,
+    `parent_execution_log_id: branch_log.id`, `state: :idle`); `insert_all(…, unique_by:
+    :key)` (on-conflict-ignore); enqueue only those children still `:idle` (dispatch is
+    **queue-idempotent** — a crash-resume never re-runs an already-completed/running child);
+    advance `metadata.cursors[name]` to `{ pk: batch.last.id, n: n + batch.size }`
+    (committed with the inserts).
+  - **Enumerable:** resume via `drop(n)`; child key uses `name_#{n}` (sequential index);
+    same per-chunk insert/idle-filter/enqueue/advance (`n` only).
   - Enqueue the chunk, **then** advance the cursor — a crash in between re-enqueues only
     that one chunk on resume (idempotent).
 
 ### `merge_branches(*names)` — separate poll-join
 
+Each name is validated up front: `$` is rejected via `validate_step_name_segment!`, and `,`
+(the merge step-name separator) is also rejected — both raise `InvalidStepName`.
+
 Gated by `find_or_create_execution_log!("merge$#{names.sort.join(',')}")`:
 
 1. **Completed** → return, continue.
 2. For each `name`: require it to be in `@open_branches` (opened earlier this pass) — a name
-   that was never opened **raises `ArgumentError`**; a not-yet-sealed branch means "still
-   dispatching".
+   that was never opened **raises `UnknownBranchError`** (a `NotExecutableError` subclass,
+   so it fail-fasts via the existing rescue without broadening the executor); a not-yet-sealed
+   branch means "still dispatching".
 3. **Capped-count probe** per branch:
    `branch_log.spawned_workflows.where.not(state: :completed).limit(CAP).count`
    (`where(parent_execution_log_id: branch_log.id, …)`, index-only, **O(CAP) not O(N)**).
@@ -253,7 +228,7 @@ parent isn't replayed per check:
   if pending.zero? && all_sealed?(branch_log_ids)
     ParentWorkflow.perform_later(parent_key)                 # wake the parent once
   else
-    rekick_dropped_jobs(branch_log_ids)                      # started_at re-kick lives here
+    rekick_dropped_jobs(branch_log_ids)                      # idle re-kick lives here
     delay = [[pending * factor, min_interval].max, max_interval].min   # adaptive cadence
     self.class.set(wait: delay).perform_later(parent_key, branch_log_ids, min_interval, max_interval)
   end
@@ -262,9 +237,10 @@ parent isn't replayed per check:
   `merge_branches` re-checks, marks the `merge$<names>` log `completed`, and continues.
   **The parent completes its own merge step** — the poller only *detects* and wakes.
 
-`merge_branches` (and the automerge gate) **(re)spawn a poller whenever reached while
-still pending**, so a manual retry of a parked parent self-heals a lost poller; a rare
-double-poller from an external re-trigger is harmless (the wake is idempotent).
+`merge_branches` **(re)spawns a poller whenever reached while still pending**, so a manual
+retry of a parked parent self-heals a lost poller (including when the poller was spawned by
+an automerge inline call); a rare double-poller from an external re-trigger is harmless (the
+wake is idempotent).
 
 **No separate recovery poll.** The poller is a durable backend-scheduled job — the same
 durability `wait_until`'s reschedule already relies on. A lost poller just parks the
@@ -274,41 +250,45 @@ counter, no per-child shared write, no hot-row contention at any scale; latency 
 toward `min_interval` as the branch nears done. Option A falls out — a failed child keeps
 pending > 0, so the parent waits until it is recovered.
 
-### Completion gate — automerge, and "every branch must be merged"
+### Completion gate — every branch must be joined
 
 Every branch must be joined — explicitly via `merge_branches` or implicitly via
-`automerge: true`. **There is no detached branch.** `complete_workflow!` gains a gate
-**before** it seals the workflow that inspects `@open_branches` — the in-memory registry
-that `branch` populated and `merge_branches` pruned during this pass (rebuilt
-deterministically every replay, so it's exact):
+`automerge: true`. **There is no detached branch.** `complete_workflow!` (`enforce_branch_joins!`)
+gains a gate **before** it seals the workflow that inspects `@open_branches` — the in-memory
+registry that `branch` populated and `merge_branches` pruned during this pass (rebuilt
+deterministically every replay, so it's exact). The gate does **only** the unmerged-raise
+check:
 
-1. **Unmerged check:** any leftover branch with `automerge == false` is a forgotten join →
-   **raise `UnmergedBranchError`** naming the branch(es), with the hint *"add
+1. **Unmerged check:** any branch remaining in `@open_branches` at completion is a forgotten
+   join → **raise `UnmergedBranchError`** naming the branch(es), with the hint *"add
    `merge_branches :x` or `branch(:x, automerge: true)`."* This fails the workflow fast
    rather than letting children run orphaned; the developer fixes the code and retries. The
    check is unconditional (fires even if the branch's children happen to have finished) so
    the contract is deterministic, not timing-dependent.
-2. **Automerge join:** for every leftover branch with `automerge == true` not yet done, run
-   the merge logic. If all are done, the workflow completes. If any is incomplete, **do not
-   complete** — enqueue a `BranchMergeJob` over those `log_id`s and `halt_execution!`; the
-   poller wakes the parent, which re-reaches the gate and seals once they finish.
 
 (A branch joined via `merge_branches` was already deleted from `@open_branches` when that
-merge completed, so it's absent here — neither raised nor re-joined.)
+merge completed, so it's absent here. An `automerge: true` branch is also absent — its join
+ran inline at the `branch` block's close, removing it from `@open_branches` before
+execution ever continued past the block.)
 
 ## Determinism
 
 The cursor is only meaningful if iteration is reproducible across replays:
 
-- **Item index:** items are keyed `name_{index}` by their **sequential position** in the
+- **AR relation:** children are keyed by **primary key** (`name_<record.id>`), so the
+  mapping from record to child key is stable regardless of enumeration order. Iteration is
+  driven by **primary-key keyset** (`in_batches(start:)`). `spawn_each` rejects a relation
+  carrying an explicit `.order(...)` by checking `order_values.present?` up front (raises
+  `NotExecutableError`) — relying on `find_in_batches`'s `error_on_ignore` is not
+  sufficient because `find_in_batches(start:)` is inclusive and a crash-resume re-yields
+  the boundary record; the explicit up-front check catches order conflicts before any
+  inserts occur.
+- **Enumerable:** items are keyed `name_{index}` by their **sequential position** in the
   stream, so the source must re-enumerate identically across replays (effectively frozen
   for the brief dispatch window — once the branch seals, replay skips the block, so no
-  re-enumeration happens thereafter).
-- **AR relation:** iteration is driven by **primary-key keyset** (`in_batches(start:)`)
-  with the index as a running counter; `error_on_ignore: true` makes a relation carrying
-  its own `.order(...)` **raise**.
-- **Enumerable:** deterministic re-enumeration is a documented, unverifiable contract —
-  misuse is still *safe* (`insert_all`-ignore + poll) but could dispatch the wrong set.
+  re-enumeration happens thereafter). Deterministic re-enumeration is a documented,
+  unverifiable contract — misuse is still *safe* (`insert_all`-ignore + poll) but could
+  dispatch the wrong set.
 
 ## Idempotency & crash recovery
 
@@ -323,14 +303,17 @@ Three layers — **what exists** (DB), **how far dispatch got** (cursor), **step
   Recovery resumes from the cursor and re-touches **one chunk**, not the whole set.
   *(Dispatch is not bound to the create block: a crash after the log is created must still
   create and enqueue the remaining rows, or the branch would stall forever.)*
-- **`started_at`/`executable?` for dropped jobs.** A child dispatched but never run is
-  re-kicked from the `BranchMergeJob` poll: re-enqueue children with `started_at IS NULL`
-  in an incomplete branch. *Child existence is not enough; the merge guarantees every
-  member is actually queued.* (verbatim into the code comment.) Safe because re-enqueue is
-  idempotent: `executable?` is `idle || running`, so `acquire_lock` raises
-  `NotExecutableError` for a `completed` child (its dispatch can never double-fire) and
-  `ConcurrentExecutionError` for a `running` one. Started children (running, mid-halt,
-  stalled/failed under Option A) have `started_at` set and are excluded.
+- **`:idle` filter for dropped jobs.** A child dispatched but never run is re-kicked from
+  the `BranchMergeJob` poll: re-enqueue branch children with `state: :idle` in an
+  incomplete branch. Branch children are pre-inserted with `state: :idle` and never get
+  `started_at` set before execution, so `:idle` is the correct "never picked up" signal
+  (filtering by `started_at IS NULL` would be unreliable). *Child existence is not enough;
+  the merge guarantees every member is actually queued.* (verbatim into the code comment.)
+  The re-kick is batch-capped. Safe because re-enqueue is idempotent: `executable?` is
+  `idle || running`, so `acquire_lock` raises `NotExecutableError` for a `completed` child
+  (its dispatch can never double-fire) and `ConcurrentExecutionError` for a `running` one.
+  Children in other states (running, mid-halt, stalled/failed under Option A) are excluded
+  by the `:idle` filter.
 
 ### Recovery walkthrough — 300,000 children, crash at 250,000
 
@@ -380,8 +363,9 @@ irreducible for N sub-workflows, done in bounded chunks by one parent job.
   job enqueue batching is best-effort.
 
 Other caveats to verify in the plan:
-- `in_batches` `start:`/`error_on_ignore:` semantics and the per-adapter bind-param limit
-  for the `of:` chunk size (notably SQLite's `SQLITE_MAX_VARIABLE_NUMBER`).
+- `in_batches` `start:` semantics (inclusive boundary — the boundary record is re-yielded on
+  crash-resume; PK-keyed children dedup via `insert_all`-ignore) and the per-adapter
+  bind-param limit for the `of:` chunk size (notably SQLite's `SQLITE_MAX_VARIABLE_NUMBER`).
 - The merge capped count must be index-only on `(parent_execution_log_id, state)`.
 
 ## Poll-cadence constants (class-configurable defaults)
@@ -434,21 +418,23 @@ workflow `state`, `execution_logs`).
   right `job_class` per item (and they bulk-enqueue together).
 - **Determinism guard:** an AR relation with a conflicting `.order(...)` **raises**.
 - **Crash mid-dispatch (cursor resume):** glitch after chunk *k*; assert
-  `metadata.cursors[name]` (`{pk, n}`) persisted, dispatch resumes from it (not 0), final child
-  count correct, no duplicate rows, only the in-flight chunk re-enqueued. (250k-of-300k.)
-- **Dropped-job re-kick:** a sealed branch with a child whose job was lost (`started_at`
-  nil, incomplete); assert the poll re-enqueues exactly that child and then resolves.
+  `metadata.cursors[name]` (`{ pk:, n: }` for AR; `{ n: }` for enumerable) persisted,
+  dispatch resumes from it (not 0), final child count correct, no duplicate rows, only the
+  in-flight chunk re-enqueued. (250k-of-300k.)
+- **Dropped-job re-kick:** a sealed branch with a child whose job was lost (state `:idle`,
+  never started); assert the poll re-enqueues exactly that child and then resolves.
 - **Poll job:** assert the parent runs only twice (kick-off + wake) regardless of poll
   count; a manual retry of a parked parent re-spawns the poller.
 - **Adaptive cadence:** assert the count is capped at `CAP` (a branch with ≫CAP incomplete
   issues an O(CAP) count and picks `max_interval`); the delay shrinks toward `min_interval`
   as pending drops.
-- **Automerge:** an `automerge: true` branch with **no** `merge_branches` blocks workflow
-  completion until its children finish; an automerge branch already merged explicitly is a
-  no-op at the gate.
+- **Automerge:** an `automerge: true` branch blocks execution inline at the block's close
+  (not at workflow completion) — assert execution does not continue past the block until
+  children finish, and that the `merge$<name>` log exists and is `completed` before the
+  next step runs. No explicit `merge_branches` is needed.
 - **Unmerged branch raises:** a branch opened with neither `merge_branches` nor
-  `automerge: true` raises `UnmergedBranchError` at the completion gate (even if its
-  children already finished — the check is unconditional), naming the branch.
+  `automerge: true` raises `UnmergedBranchError` at the completion gate (unconditional —
+  fires even if children already finished), naming the branch.
 - **Option A:** a child `permanently_fail`s → merge parks; recover via `retry_later` →
   merge resolves; assert no progress while parked.
 - **Idempotency / replay:** force replays; assert constant child count, no re-dispatch once
@@ -467,10 +453,11 @@ Surface these prominently in user-facing docs, not just here:
 - **Every branch must be merged or `automerge: true`** — otherwise `UnmergedBranchError`.
 - **The heavy parent is not replayed per poll** — a lightweight `BranchMergeJob` does the
   waiting; the parent runs twice per merge.
-- **Source must be stable during a branch's dispatch window** — items are keyed
-  `name_{index}` by stream position, so inserting/removing rows mid-dispatch (before a
-  crash-replay seals the branch) shifts indices. `error_on_ignore: true` catches *ordering*
-  mistakes, not *insertion*. Once sealed, the block never re-enumerates.
+- **AR source must be stable during a branch's dispatch window** — AR items are keyed by
+  primary key (`name_<id>`), so inserting rows mid-dispatch is safe but re-use of a PK
+  (soft-delete/re-insert) can confuse the cursor. Plain enumerables are keyed by sequential
+  index; inserting/removing items mid-dispatch (before a crash-replay seals the branch)
+  shifts indices. Once sealed, the block never re-enumerates.
 
 ## Future work
 

--- a/docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md
+++ b/docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md
@@ -1,0 +1,481 @@
+# Branches — Concurrent Sub-Workflows (`branch` / `spawn` / `merge_branches`) — Design
+
+**Date:** 2026-06-25
+**Status:** Implemented (`feat/branches`). See "Implementation deltas" below for where
+the shipped behavior refined this design during the build.
+
+> ## Implementation deltas (as shipped — these override the body below)
+>
+> The feature was built and reviewed task-by-task; a few decisions were refined mid-build
+> and the shipped code is the source of truth where it differs from this document:
+>
+> 1. **Automerge joins INLINE at the branch block's close**, not deferred to a workflow
+>    completion gate. `branch(name, automerge: true)` ≡ eager dispatch inside the block
+>    followed immediately by `merge_branches(name)` — execution does not continue past the
+>    block until the branch's children complete. (The "Completion gate — automerge" section
+>    below describes the abandoned deferred design.) The completion gate now does only the
+>    **unmerged-raise** check: any branch left in `@open_branches` at completion (i.e.
+>    opened but neither `merge_branches`-d nor automerged) raises `UnmergedBranchError`.
+> 2. **`merge_branches` of an unopened name raises `UnknownBranchError`** (a
+>    `NotExecutableError` subclass), not `ArgumentError` — so it fail-fasts via the existing
+>    rescue without broadening the executor. `merge_branches` also validates each name
+>    (`$` and `,` are rejected — `,` is the merge step-name separator).
+> 3. **AR `spawn_each` children are keyed by record primary key** (`name_<record.id>`), not
+>    a sequential index. `find_in_batches(start:)` is inclusive, so a crash-resume re-yields
+>    the boundary record under the SAME key and `insert_all`-ignore dedups it (idempotent).
+>    Plain (non-AR) enumerables keep `name_<index>` + `drop(n)` (exclusive, already safe).
+> 4. **An explicit `.order` on an AR source raises** (iteration is by PK); `spawn_each`
+>    checks `order_values.present?` up front rather than relying on `find_in_batches`'s
+>    `error_on_ignore`.
+> 5. **Dispatch is queue-idempotent:** after `insert_all`, only children still `:idle` are
+>    enqueued, so a crash-resume never re-runs an already-completed/running child.
+> 6. **The dropped-job re-kick filters by `state: :idle`**, not `started_at IS NULL` —
+>    branch children are pre-inserted and never get `started_at` set, so `:idle` is the
+>    correct "never picked up" signal. The re-kick is batch-capped.
+> 7. **`merge/automerge state is in-memory only** (`@open_branches`), rebuilt each replay
+>    pass — no persisted `merged`/`automerge` flags (as the body already states).
+>
+> Everything else in this document matches the implementation.
+
+**Original status:** Draft (pending spec review)
+**Scope:** New public API, additive. Introduces parent/child workflows and a
+fan-out/fan-in primitive built to dispatch **hundreds of thousands** of children per
+branch. One new (generic, reusable) column on `chrono_forge_workflows`; reuses the
+execution-log pattern for coordination. No breaking change to existing single-workflow
+execution. **New dependency floor:** `activejob >= 7.1` (for `perform_all_later`).
+
+## Problem
+
+ChronoForge workflows are strictly sequential. The only way to fan work out today is to
+hand-enqueue independent workflows and poll for them with `wait_until` — a hand-rolled
+fork/join with no idempotent dispatch and no parent/child visibility.
+
+Real workflows need durable, large-scale fan-out: "spawn one sub-workflow per record
+across a 500k-row set, run them in parallel, continue once all are done." It must be
+crash-safe, idempotent under replay, and must not hold the batch in memory or serialize
+on a hot row.
+
+## Goal
+
+A **branch** is the unit of fan-out — a durable step that wraps the work it spawns and
+ties it together for the join. `spawn`/`spawn_each` exist **only inside a `branch`
+block**. The model mirrors git: you branch, then you merge.
+
+- `branch(name, automerge: false, &block)` — opens branch `name` (the durable
+  `branch$<name>` log), runs the block to **eagerly dispatch** children, and **seals**
+  when the block closes. Returns immediately (does **not** wait) so branches run
+  concurrently.
+- `spawn(name, WorkflowClass, **kwargs)` — inside a branch: dispatch a **single** named
+  child.
+- `spawn_each(name, source, of:) { |item| [WorkflowClass, kwargs] }` — inside a branch:
+  dispatch **one child per item**, streamed like ActiveRecord batch loading; items are
+  keyed `name_{index}` (sequential index across the stream).
+- `merge_branches(*names)` — the **separate** join: halt until every named branch is
+  sealed **and** all its children have completed.
+
+```ruby
+def perform(cycle_id:)
+  branch :fulfillment, automerge: true do        # the step; seals when the block closes
+    spawn :reconcile, ReconcileWorkflow, region: "EU"   # single child of :fulfillment
+    spawn_each :orders, Order.pending do |order|        # bulk, streamed; keys orders_0, orders_1…
+      order.priority? ? [PriorityOrderWorkflow, { order_id: order.id }]
+                      : [OrderWorkflow, { order_id: order.id }]
+    end
+  end
+
+  branch :invoicing do                           # a second, concurrent branch
+    spawn_each :invoices, Invoice.unpaid do |inv|
+      [InvoiceWorkflow, { invoice_id: inv.id }]
+    end
+  end
+
+  do_other_work                                  # both branches already running
+
+  merge_branches :invoicing                      # join :invoicing; :fulfillment auto-merges
+  durably_execute :finalize
+end
+```
+
+## Decisions (locked during brainstorming)
+
+| Decision | Choice |
+|---|---|
+| Keywords | **`branch` / `spawn` / `spawn_each` / `merge_branches`** — git branch/merge metaphor; `spawn` avoids shadowing `Kernel#fork`. |
+| Branch = the step | A branch **is** its `branch$<name>` execution log. `spawn`/`spawn_each` are valid **only inside a `branch` block** (raise otherwise) — spawns don't exist without a branch. |
+| Dispatch timing | **Eager.** Spawns insert + enqueue as the block runs; children start at once. The branch **seals** (log → `completed`) when the block closes. |
+| Join | **Separate `merge_branches`** so branches run concurrently and work can happen in between. Joins one or more named branches at once (`merge_branches :a` for one). |
+| `merge_branch` alias | **Ship a singular `merge_branch(name, **opts)` alias** that delegates to `merge_branches` — reads naturally for the common one-branch case (`merge_branch :a`) without a plural-method/singular-arg mismatch. Decided, not just mentioned. |
+| Automerge | A property **of the branch**: `branch(name, automerge: true)`. When `true`, the branch is auto-joined just before workflow completion (an implicit final merge), so no explicit `merge_branches` is needed. |
+| Branch tracking | An **in-memory registry** (`@open_branches`), rebuilt each replay pass: `branch` adds, `merge_branches` removes on completion, the completion gate inspects the remainder. Deterministic replay makes it exact — no persisted `merged`/`automerge` flags. |
+| Every branch must be joined | **No detached branches.** A branch left in `@open_branches` at completion with `automerge: false` **raises `UnmergedBranchError`** (fail-fast on a forgotten join), rather than silently letting children run orphaned. |
+| Spawn identity | Spawns are **named** (`spawn :reconcile, …`, `spawn_each :orders, …`). The name anchors the child key and the per-`spawn_each` cursor — stable across code reordering (unlike a positional ordinal). A `spawn_each`'s items are keyed `name_{index}` (sequential index across the stream). |
+| Bulk source | `spawn_each` **streams** the source — `in_batches(of:, start: cursor)` for AR — never materialising the batch in memory. Scales to millions. |
+| Child class | **Returned from the block** (`[WorkflowClass, kwargs]`); one branch may fan out into mixed workflow types. |
+| Child key | Deterministic: `spawn` → `"#{parent.key}$#{branch}$#{spawn_name}"`; `spawn_each` item → `"#{parent.key}$#{branch}$#{spawn_name}_#{index}"`. Idempotency falls out of the unique-key constraint. |
+| Cursor | Per `spawn_each`, stored in the `branch$<name>` log's `metadata` keyed by **spawn name** as `{ pk: <keyset>, n: <count/index> }`; persisted **once per dispatched chunk** (bundled with that chunk's `insert_all`). |
+| Completion | **Poll**, no counter: a branch is done when sealed and has no incomplete children (`branch_log.spawned_workflows.where.not(state: :completed)` empty — read as an O(CAP) capped count). Zero per-completion contention. |
+| Poll mechanism | A dedicated lightweight `ChronoForge::BranchMergeJob` (plain ActiveJob — no lock/replay/context) does the repeated probing and wakes the parent only at completion. The heavy parent runs just twice per merge (kick off + wake). No separate recovery timer. |
+| Poll cadence | **Adaptive, capped-count.** `pending = incomplete.limit(CAP).count` (**O(CAP)**, never O(N)); next delay `clamp(pending * factor, min_interval, max_interval)` — fast when few remain, slow when many. |
+| Determinism | Items are keyed by **sequential index**, so the stream must re-enumerate identically across replays. AR sources iterate by PK keyset with `error_on_ignore: true` (a conflicting `.order` **raises**); the index is a running counter alongside the keyset. Non-AR enumerables must re-enumerate deterministically (documented contract). |
+| Failure semantics | **Option A.** A `stalled`/`failed` child keeps the branch incomplete; the parent stays parked; the user recovers the child (`retry_now`/`retry_later`) and the merge then resolves. No new failure states, no cascade. |
+| Nesting | **Free.** A child is a workflow and may open its own branches; the tree forms via `parent_execution_log_id` (child → branch log → parent workflow). |
+
+## Public API surface
+
+```ruby
+branch(name, automerge: false) do
+  spawn(name, WorkflowClass, **kwargs)
+  spawn_each(name, source, of: 1000) { |item| [WorkflowClass, kwargs] }
+end
+
+merge_branches(*names, min_interval: 5.seconds, max_interval: 5.minutes)  # halts until done
+merge_branch(name, **opts)   # singular alias for the common one-branch case
+```
+
+`spawn`/`spawn_each` raise `NotInBranchError` if called outside a `branch` block. A branch
+opened but neither `merge_branches`-d nor `automerge: true` raises `UnmergedBranchError` at
+workflow completion.
+
+## Data model
+
+`chrono_forge_workflows` gains **one** nullable column (inline in the install migration;
+a follow-up migration template for existing installs):
+
+| Column | Type | Notes |
+|---|---|---|
+| `parent_execution_log_id` | FK → `chrono_forge_execution_logs.id`, nullable, indexed | The execution log that spawned this workflow. For branches it's the `branch$<name>` log. **Deliberately generic** — any future step that spawns sub-workflows reuses it. |
+
+The branch a child belongs to *is* its `parent_execution_log_id` (the `branch$<name>`
+log), which is globally unique and encodes both the parent workflow (the log's
+`workflow_id`) and the branch (its `step_name`). No `branch_name`/`parent_workflow_id`
+column is needed.
+
+**Merge/automerge state is not persisted.** It's tracked in an in-memory registry rebuilt
+each replay pass from the `branch`/`merge_branches` calls (see Execution flow) — `branch`
+adds, `merge_branches` removes, the completion gate inspects the remainder. Deterministic
+replay makes this exact every pass, so no `merged`/`automerge` columns or metadata flags
+are needed; the branch log holds only dispatch cursors.
+
+**Composite index** `(parent_execution_log_id, state)` — makes the merge capped count
+and the dropped-job re-kick index-only and short-circuiting at millions of rows.
+
+No new table. The branch is the **`branch$<name>`** execution log (two-segment, like
+`durably_repeat`'s coordination log — preloaded when sealed, never per child):
+
+```
+step_name: "branch$fulfillment"
+state:     pending (dispatching) | completed (sealed / block closed)
+metadata:  { "cursors" => { "orders" => { "pk" => <keyset>, "n" => <count> } } }  # keyed by spawn name
+```
+
+The **`merge$<names>`** log coordinates a join (`pending` while polling → `completed`).
+
+`Workflow belongs_to :parent_execution_log, class_name: "ExecutionLog", optional: true`;
+`ExecutionLog has_many :spawned_workflows, class_name: "Workflow", foreign_key: :parent_execution_log_id`.
+A branch's children are `branch_log.spawned_workflows`; the parent is `branch_log.workflow`.
+
+### One bounded log per branch — preload safety
+
+The preload (`completed_step_cache`) bulk-loads all `completed` logs except
+`durably_repeat$%$%` (the unbounded three-segment repetition logs). A two-segment
+`branch$<name>` is preloaded when sealed, so a replay past the branch short-circuits.
+**Per-child state is never modelled as sub-segment logs** (`branch$<name>$<child>`):
+those would be pulled into the preload and load millions of rows on every replay.
+Per-child state lives on the child workflow rows; the branch log holds only cursors.
+
+## Execution flow
+
+### `branch(name, automerge:) { … }` — wrap + eager dispatch + seal
+
+Gated by `find_or_create_execution_log!("branch$#{name}")` (the branch log holds only
+dispatch cursors; `automerge`/merge state is in-memory, not seeded here):
+
+1. **Sealed** (`completed`, served from `completed_step_cache`) → already fully
+   dispatched; **skip the block entirely** (no re-stream) and return. *(This short-circuit
+   is the single most important correctness/performance property in the design — the
+   expensive source enumeration never re-runs after sealing. It warrants a prominent comment
+   directly above the skip path in the implementation.)*
+2. **Pending / new** → set the current-branch context, **yield the block** (named spawns
+   dispatch into this branch, advancing their cursors — see below), clear the context,
+   mark the `branch$<name>` log `completed` (**sealed**), and **return** (do not halt —
+   branches are concurrent; the join is separate).
+
+Either way, `branch` **registers the branch in the in-memory registry**
+`@open_branches[name] = { automerge:, log_id: }` — this runs on *every* pass (sealed or
+not), since the `branch` method itself always executes even when its block is skipped.
+
+`spawn`/`spawn_each` read the current branch from that context and raise
+`NotInBranchError` if there is none.
+
+### `spawn` / `spawn_each` — dispatch within a branch
+
+- **`spawn(name, klass, **kwargs)`** → one child, key `"#{parent.key}$#{branch}$#{name}"`,
+  `job_class: klass.name`, `parent_execution_log_id: branch_log.id`. Idempotent on the key.
+- **`spawn_each(name, source, of:)`** → stream, resuming from `metadata.cursors[name]`
+  (`{ pk:, n: }`); `n` is the running item index:
+  - **AR relation:** `source.in_batches(of:, start: cursor.pk, error_on_ignore: true)`. Per
+    batch, for each record (index `i = n, n+1, …`): `klass, kw = yield(record)`; build child
+    rows (key `"#{parent.key}$#{branch}$#{name}_#{i}"`, `job_class`, `kwargs`,
+    `parent_execution_log_id: branch_log.id`, `state: :idle`); `insert_all(…, unique_by: :key)`
+    (on-conflict-ignore); build the child **job instances** (`klass.new(child_key, **kw)`,
+    validating String key / no reserved kwargs — `perform_all_later` bypasses the class
+    `perform_later` guard) and `ActiveJob.perform_all_later(jobs)`; advance `metadata.cursors[name]` to
+    `{ pk: batch.last.id, n: i+1 }` (committed with the inserts).
+  - **Enumerable:** resume via `drop(n)`; same per-chunk insert/enqueue/advance (`n` only).
+  - Enqueue the chunk, **then** advance the cursor — a crash in between re-enqueues only
+    that one chunk on resume (idempotent).
+
+### `merge_branches(*names)` — separate poll-join
+
+Gated by `find_or_create_execution_log!("merge$#{names.sort.join(',')}")`:
+
+1. **Completed** → return, continue.
+2. For each `name`: require it to be in `@open_branches` (opened earlier this pass) — a name
+   that was never opened **raises `ArgumentError`**; a not-yet-sealed branch means "still
+   dispatching".
+3. **Capped-count probe** per branch:
+   `branch_log.spawned_workflows.where.not(state: :completed).limit(CAP).count`
+   (`where(parent_execution_log_id: branch_log.id, …)`, index-only, **O(CAP) not O(N)**).
+   All `0` → done. Otherwise enqueue a `BranchMergeJob` (which polls + re-kicks dropped
+   jobs) and `halt_execution!`.
+4. All branches `0` pending → **delete those names from `@open_branches`** (so the
+   completion gate sees them as joined), mark the `merge$…` log `completed`, continue.
+
+Completion is **poll-based**, delegated to a dedicated lightweight job so the heavy
+parent isn't replayed per check:
+
+- `merge_branches` does **one** immediate check; if not done, enqueues
+  `ChronoForge::BranchMergeJob` and `halt_execution!`s (parent → `idle`, lock released).
+  The parent runs only **twice** per merge: kick off + completion wake.
+- **`BranchMergeJob`** is a plain ActiveJob — *no* lock, replay, or context. Each run:
+  ```ruby
+  pending = branch_log_ids.sum { |id| incomplete(id).limit(CAP).count }   # O(CAP), index-only
+  if pending.zero? && all_sealed?(branch_log_ids)
+    ParentWorkflow.perform_later(parent_key)                 # wake the parent once
+  else
+    rekick_dropped_jobs(branch_log_ids)                      # started_at re-kick lives here
+    delay = [[pending * factor, min_interval].max, max_interval].min   # adaptive cadence
+    self.class.set(wait: delay).perform_later(parent_key, branch_log_ids, min_interval, max_interval)
+  end
+  ```
+- On the wake, the parent replays once; sealed branches short-circuit (no re-stream),
+  `merge_branches` re-checks, marks the `merge$<names>` log `completed`, and continues.
+  **The parent completes its own merge step** — the poller only *detects* and wakes.
+
+`merge_branches` (and the automerge gate) **(re)spawn a poller whenever reached while
+still pending**, so a manual retry of a parked parent self-heals a lost poller; a rare
+double-poller from an external re-trigger is harmless (the wake is idempotent).
+
+**No separate recovery poll.** The poller is a durable backend-scheduled job — the same
+durability `wait_until`'s reschedule already relies on. A lost poller just parks the
+parent with a pending `merge$…` log, recoverable by retry (Option A). Cost: one tiny job
+per (adaptive) interval plus an **O(CAP)** index-only capped count per branch — no
+counter, no per-child shared write, no hot-row contention at any scale; latency falls
+toward `min_interval` as the branch nears done. Option A falls out — a failed child keeps
+pending > 0, so the parent waits until it is recovered.
+
+### Completion gate — automerge, and "every branch must be merged"
+
+Every branch must be joined — explicitly via `merge_branches` or implicitly via
+`automerge: true`. **There is no detached branch.** `complete_workflow!` gains a gate
+**before** it seals the workflow that inspects `@open_branches` — the in-memory registry
+that `branch` populated and `merge_branches` pruned during this pass (rebuilt
+deterministically every replay, so it's exact):
+
+1. **Unmerged check:** any leftover branch with `automerge == false` is a forgotten join →
+   **raise `UnmergedBranchError`** naming the branch(es), with the hint *"add
+   `merge_branches :x` or `branch(:x, automerge: true)`."* This fails the workflow fast
+   rather than letting children run orphaned; the developer fixes the code and retries. The
+   check is unconditional (fires even if the branch's children happen to have finished) so
+   the contract is deterministic, not timing-dependent.
+2. **Automerge join:** for every leftover branch with `automerge == true` not yet done, run
+   the merge logic. If all are done, the workflow completes. If any is incomplete, **do not
+   complete** — enqueue a `BranchMergeJob` over those `log_id`s and `halt_execution!`; the
+   poller wakes the parent, which re-reaches the gate and seals once they finish.
+
+(A branch joined via `merge_branches` was already deleted from `@open_branches` when that
+merge completed, so it's absent here — neither raised nor re-joined.)
+
+## Determinism
+
+The cursor is only meaningful if iteration is reproducible across replays:
+
+- **Item index:** items are keyed `name_{index}` by their **sequential position** in the
+  stream, so the source must re-enumerate identically across replays (effectively frozen
+  for the brief dispatch window — once the branch seals, replay skips the block, so no
+  re-enumeration happens thereafter).
+- **AR relation:** iteration is driven by **primary-key keyset** (`in_batches(start:)`)
+  with the index as a running counter; `error_on_ignore: true` makes a relation carrying
+  its own `.order(...)` **raise**.
+- **Enumerable:** deterministic re-enumeration is a documented, unverifiable contract —
+  misuse is still *safe* (`insert_all`-ignore + poll) but could dispatch the wrong set.
+
+## Idempotency & crash recovery
+
+Three layers — **what exists** (DB), **how far dispatch got** (cursor), **step state**
+(the log).
+
+- **`find_or_create_execution_log!`** — a sealed `branch$<name>` skips the whole block;
+  a completed `merge$…` short-circuits the join.
+- **Deterministic keys + per-spawn cursors = "which children exist."** The branch never
+  tracks children individually. Existence is owned by the unique index (`insert_all`-ignore
+  is a no-op for rows that exist); dispatch progress is owned by `metadata.cursors[name]`.
+  Recovery resumes from the cursor and re-touches **one chunk**, not the whole set.
+  *(Dispatch is not bound to the create block: a crash after the log is created must still
+  create and enqueue the remaining rows, or the branch would stall forever.)*
+- **`started_at`/`executable?` for dropped jobs.** A child dispatched but never run is
+  re-kicked from the `BranchMergeJob` poll: re-enqueue children with `started_at IS NULL`
+  in an incomplete branch. *Child existence is not enough; the merge guarantees every
+  member is actually queued.* (verbatim into the code comment.) Safe because re-enqueue is
+  idempotent: `executable?` is `idle || running`, so `acquire_lock` raises
+  `NotExecutableError` for a `completed` child (its dispatch can never double-fire) and
+  `ConcurrentExecutionError` for a `running` one. Started children (running, mid-halt,
+  stalled/failed under Option A) have `started_at` set and are excluded.
+
+### Recovery walkthrough — 300,000 children, crash at 250,000
+
+A `branch :fulfillment` block's `spawn_each :orders` had committed 250k child rows + jobs
+with `metadata.cursors["orders"]` at `{ pk: <250,000th PK>, n: 250_000 }`; it was mid-chunk
+when the process died. The `branch$orders` log is still `pending` (not sealed), so workflow retry replays
+from the top. The block re-runs; `spawn_each` resumes `in_batches(start: cursor)` from PK
+250,000 — re-touching ~50k rows, worst-case duplicate enqueue is the single in-flight
+chunk. The 250k already dispatched keep running the whole time. When the source is
+exhausted the block closes and the branch seals; `merge_branches`/automerge then polls to
+completion. Recovery is bounded and idempotent — never a re-fan-out of 300k.
+
+## Scale & performance (target: hundreds of thousands per branch)
+
+| Operation | Frequency | Cost |
+|---|---|---|
+| `spawn_each` dispatch | once per branch, **streamed** | `⌈N/of⌉` `insert_all` + `perform_all_later`, each advancing the cursor — O(N) total, bounded chunks, **constant memory** |
+| Child run | per child | one own-row state transition — **no shared-row contention** |
+| Merge poll | per adaptive interval | lightweight `BranchMergeJob` running an **O(CAP)** capped count per branch; interval scales `min`↔`max` with pending — the heavy parent is *not* replayed per poll |
+| Crash recovery | once | resumes dispatch from the cursor — re-touches **one chunk** |
+| Replay cost | per resume | independent of how many children finished — no member list, no sibling scan, no counter |
+
+What deliberately does **not** exist: an in-memory fork registry (streamed instead), a
+single hot completion counter (adaptive capped-count poll instead), and a member-key blob
+in metadata (just per-spawn cursors). The remaining O(N) work — N rows + N jobs — is
+irreducible for N sub-workflows, done in bounded chunks by one parent job.
+
+### `perform_all_later` — verified (activejob 7.1.3.4)
+
+- **Mixed job classes: supported, no same-class requirement.** `perform_all_later` groups
+  by `queue_adapter` (`enqueuing.rb:18`); the adapter's `enqueue_all` then sub-groups by
+  **class then queue** (e.g. core Sidekiq adapter does `group_by(&:class).group_by(&:queue_name)`
+  → one `push_bulk` per group, `sidekiq_adapter.rb:36`). So a `spawn_each` returning mixed
+  workflow types is fine — enqueue just batches per distinct (class, queue), never falling
+  back to per-job for being heterogeneous.
+- **It bypasses ChronoForge's class-level `perform_later` override** (`__validate_enqueue!`)
+  and **ActiveJob enqueue callbacks** — it builds instances and hits the adapter directly.
+  So `spawn`/`spawn_each` must **build child job instances and validate them
+  (String key, no reserved kwargs) themselves**, then `ActiveJob.perform_all_later(jobs)`.
+  Execution is unaffected (the executor's logic is in instance `perform`). This mirrors the
+  existing sanctioned `.set(...)`-bypasses-the-override pattern.
+- **Requires activejob ≥ 7.1.** The gemspec currently pins no version — add
+  `spec.add_dependency "activejob", ">= 7.1"` (or provide a `perform_later`-loop fallback).
+- **Bulk enqueue is adapter-dependent.** Only adapters implementing `enqueue_all`
+  (Sidekiq in core; solid_queue/good_job ship their own) batch the enqueue; Test/Inline/
+  Async fall back to per-job `enqueue`. The `insert_all` of child rows is **always** bulk;
+  job enqueue batching is best-effort.
+
+Other caveats to verify in the plan:
+- `in_batches` `start:`/`error_on_ignore:` semantics and the per-adapter bind-param limit
+  for the `of:` chunk size (notably SQLite's `SQLITE_MAX_VARIABLE_NUMBER`).
+- The merge capped count must be index-only on `(parent_execution_log_id, state)`.
+
+## Poll-cadence constants (class-configurable defaults)
+
+- `CAP` (capped-count limit) — default `5_000`. Bounds each poll's count cost; beyond it,
+  pending saturates to `max_interval` (no signal lost).
+- `factor` — maps pending → delay; default tuned so ~100 → ~10s, ~1k → ~1 min.
+- `min_interval` / `max_interval` — clamp; defaults `5.seconds` / `5.minutes`
+  (per-`merge_branches` overridable; `automerge` uses the defaults).
+
+## Naming & validation
+
+- `STEP_NAME_DELIMITER` is `$` (executor.rb). Reserved.
+- The `branch` name, each `spawn`/`spawn_each` name, and each `merge_branches` name pass
+  through `validate_step_name_segment!` (no `$`). The merge step name joins sorted branch
+  names with `,`; names containing `,` are rejected. (`name_{index}` uses `_`, which is
+  unreserved.)
+- Child keys use `$` (`"#{parent.key}$#{branch}$#{spawn_name}"` / `…$#{spawn_name}_#{index}"`).
+  Keys are opaque (never parsed), so a `$` already in the parent key is harmless.
+
+## Non-goals (v1) — with caveats
+
+- **Sharded completion counter / instant wake.** v1 polls (adaptive, but still polls). If
+  sub-`min_interval` wake latency is ever needed, a
+  `fork_counters(branch_log_id, shard, completed)` table (K rows/branch) is the upgrade —
+  fully internal to the branch, **zero API change**.
+- **Parallel dispatch.** One parent job streams the dispatch. At ~1M this is minutes and
+  crash-safe via the cursor; recursive dispatcher sub-jobs are a future throughput upgrade.
+- **Result aggregation.** Children communicate via their own `context`, which is
+  **workflow-scoped** — a parent can't read a child's context today. `branch_log.spawned_workflows`
+  returns the child **records**. Aggregation, when added, needs an explicit cross-workflow
+  read API.
+- **`merge_branches` timeout.** Blocks indefinitely (Option A); a `timeout:` can come later.
+- **Dashboard nesting.** Parent/child tree + per-child recovery is a follow-up; the
+  `parent_execution_log_id` column makes the tree cheap to walk.
+
+## Testing strategy
+
+Mirror the existing `ChaoticJob` style (`perform_later` + `perform_all_jobs`; assert on
+workflow `state`, `execution_logs`).
+
+- **Happy path:** a `branch` with a `spawn :a` + a `spawn_each :b`; assert child keys
+  (`…$a`, `…$b_0`, `…$b_1`, …), `parent_execution_log_id`, the branch seals,
+  `merge_branches` resumes, the workflow finishes.
+- **Spawn outside branch raises** `NotInBranchError`.
+- **Concurrency:** two branches dispatched before the merge both make progress before the
+  join; work between branch blocks and merge runs while children are in flight.
+- **Eager dispatch:** children begin before `merge_branches` is reached.
+- **Class from body:** a `spawn_each` returning mixed classes creates children with the
+  right `job_class` per item (and they bulk-enqueue together).
+- **Determinism guard:** an AR relation with a conflicting `.order(...)` **raises**.
+- **Crash mid-dispatch (cursor resume):** glitch after chunk *k*; assert
+  `metadata.cursors[name]` (`{pk, n}`) persisted, dispatch resumes from it (not 0), final child
+  count correct, no duplicate rows, only the in-flight chunk re-enqueued. (250k-of-300k.)
+- **Dropped-job re-kick:** a sealed branch with a child whose job was lost (`started_at`
+  nil, incomplete); assert the poll re-enqueues exactly that child and then resolves.
+- **Poll job:** assert the parent runs only twice (kick-off + wake) regardless of poll
+  count; a manual retry of a parked parent re-spawns the poller.
+- **Adaptive cadence:** assert the count is capped at `CAP` (a branch with ≫CAP incomplete
+  issues an O(CAP) count and picks `max_interval`); the delay shrinks toward `min_interval`
+  as pending drops.
+- **Automerge:** an `automerge: true` branch with **no** `merge_branches` blocks workflow
+  completion until its children finish; an automerge branch already merged explicitly is a
+  no-op at the gate.
+- **Unmerged branch raises:** a branch opened with neither `merge_branches` nor
+  `automerge: true` raises `UnmergedBranchError` at the completion gate (even if its
+  children already finished — the check is unconditional), naming the branch.
+- **Option A:** a child `permanently_fail`s → merge parks; recover via `retry_later` →
+  merge resolves; assert no progress while parked.
+- **Idempotency / replay:** force replays; assert constant child count, no re-dispatch once
+  sealed, replay query count independent of completed-child count (`branch$<name>` preloads
+  when sealed; no per-child sub-logs).
+- **Scale:** a branch of hundreds of thousands; assert `insert_all` issues `⌈N/of⌉` inserts
+  (not N), constant memory (streamed), contention-free child runs, and one capped probe per
+  branch per poll. (Job-enqueue batching is adapter-dependent — under the test adapter it
+  falls back to per-job enqueue, so don't assert bulk *enqueue* there.)
+- **Empty branch / empty source:** seals immediately; the merge resolves at once.
+- **Nesting:** a child opens its own branch; assert the tree completes bottom-up.
+
+## README notes (when shipping)
+
+Surface these prominently in user-facing docs, not just here:
+- **Every branch must be merged or `automerge: true`** — otherwise `UnmergedBranchError`.
+- **The heavy parent is not replayed per poll** — a lightweight `BranchMergeJob` does the
+  waiting; the parent runs twice per merge.
+- **Source must be stable during a branch's dispatch window** — items are keyed
+  `name_{index}` by stream position, so inserting/removing rows mid-dispatch (before a
+  crash-replay seals the branch) shifts indices. `error_on_ignore: true` catches *ordering*
+  mistakes, not *insertion*. Once sealed, the block never re-enumerates.
+
+## Future work
+
+- Sharded-counter table for instant (non-poll) wake.
+- Parallel/recursive dispatcher sub-jobs for dispatch throughput beyond one parent job.
+- Result aggregation via an explicit child-context read API.
+- `merge_branches(..., timeout:)`.
+- Dashboard parent/child tree + per-child recovery actions.

--- a/docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md
+++ b/docs/superpowers/specs/2026-06-25-spawn-merge-branches-design.md
@@ -74,7 +74,7 @@ end
 | Branch tracking | An **in-memory registry** (`@open_branches`), rebuilt each replay pass: `branch` adds, `merge_branches` removes on completion, the completion gate inspects the remainder. Deterministic replay makes it exact — no persisted `merged`/`automerge` flags. |
 | Every branch must be joined | **No detached branches.** Any branch remaining in `@open_branches` at completion (neither `merge_branches`-d nor automerged) **raises `UnmergedBranchError`** (fail-fast on a forgotten join), rather than silently letting children run orphaned. `automerge: true` branches are joined inline at the block close and are absent from `@open_branches` by the time the completion gate runs. |
 | Spawn identity | Spawns are **named** (`spawn :reconcile, …`, `spawn_each :orders, …`). The name anchors the child key and the per-`spawn_each` cursor — stable across code reordering (unlike a positional ordinal). AR items are keyed `name_<record.id>` (primary key); plain enumerable items are keyed `name_{index}` (sequential index). |
-| Bulk source | `spawn_each` **streams** the source — `in_batches(of:, start: cursor)` for AR — never materialising the batch in memory. Scales to millions. |
+| Bulk source | `spawn_each` **streams** the source — `find_in_batches(batch_size: of, start: cursor)` for AR — never materialising the batch in memory. Scales to millions. |
 | Child class | **Returned from the block** (`[WorkflowClass, kwargs]`); one branch may fan out into mixed workflow types. |
 | Child key | Deterministic: `spawn` → `"#{parent.key}$#{branch}$#{spawn_name}"`; AR `spawn_each` item → `"#{parent.key}$#{branch}$#{spawn_name}_#{record.id}"`; enumerable item → `"#{parent.key}$#{branch}$#{spawn_name}_#{index}"`. Idempotency falls out of the unique-key constraint. |
 | Cursor | Per `spawn_each`, stored in the `branch$<name>` log's `metadata` keyed by **spawn name** as `{ pk: <keyset>, n: <count/index> }`; persisted **once per dispatched chunk** (bundled with that chunk's `insert_all`). |
@@ -183,7 +183,7 @@ not), since the `branch` method itself always executes even when its block is sk
   (`{ pk:, n: }`); `n` is a running count (AR) or the resume index (enumerable):
   - **AR relation:** rejects `source` if `source.order_values.present?` (raises
     `NotExecutableError` — iteration is by PK and an explicit order conflicts). Resumes via
-    `source.in_batches(of:, start: cursor.pk)`. Per batch, for each record: `klass, kw =
+    `source.find_in_batches(batch_size: of, start: cursor.pk)`. Per batch, for each record: `klass, kw =
     yield(record)`; build child rows (key
     `"#{parent.key}$#{branch}$#{name}_#{record.id}"`, `job_class`, `kwargs`,
     `parent_execution_log_id: branch_log.id`, `state: :idle`); `insert_all(…, unique_by:
@@ -277,7 +277,7 @@ The cursor is only meaningful if iteration is reproducible across replays:
 
 - **AR relation:** children are keyed by **primary key** (`name_<record.id>`), so the
   mapping from record to child key is stable regardless of enumeration order. Iteration is
-  driven by **primary-key keyset** (`in_batches(start:)`). `spawn_each` rejects a relation
+  driven by **primary-key keyset** (`find_in_batches(start:)`). `spawn_each` rejects a relation
   carrying an explicit `.order(...)` by checking `order_values.present?` up front (raises
   `NotExecutableError`) — relying on `find_in_batches`'s `error_on_ignore` is not
   sufficient because `find_in_batches(start:)` is inclusive and a crash-resume re-yields
@@ -320,7 +320,7 @@ Three layers — **what exists** (DB), **how far dispatch got** (cursor), **step
 A `branch :fulfillment` block's `spawn_each :orders` had committed 250k child rows + jobs
 with `metadata.cursors["orders"]` at `{ pk: <250,000th PK>, n: 250_000 }`; it was mid-chunk
 when the process died. The `branch$orders` log is still `pending` (not sealed), so workflow retry replays
-from the top. The block re-runs; `spawn_each` resumes `in_batches(start: cursor)` from PK
+from the top. The block re-runs; `spawn_each` resumes `find_in_batches(start: cursor)` from PK
 250,000 — re-touching ~50k rows, worst-case duplicate enqueue is the single in-flight
 chunk. The 250k already dispatched keep running the whole time. When the source is
 exhausted the block closes and the branch seals; `merge_branches`/automerge then polls to
@@ -363,7 +363,7 @@ irreducible for N sub-workflows, done in bounded chunks by one parent job.
   job enqueue batching is best-effort.
 
 Other caveats to verify in the plan:
-- `in_batches` `start:` semantics (inclusive boundary — the boundary record is re-yielded on
+- `find_in_batches` `start:` semantics (inclusive boundary — the boundary record is re-yielded on
   crash-resume; PK-keyed children dedup via `insert_all`-ignore) and the per-adapter
   bind-param limit for the `of:` chunk size (notably SQLite's `SQLITE_MAX_VARIABLE_NUMBER`).
 - The merge capped count must be index-only on `(parent_execution_log_id, state)`.

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -46,13 +46,20 @@ module ChronoForge
 
       rekick_dropped_jobs(branch_log_ids)
 
-      delay = (pending * FACTOR).clamp(min_interval, max_interval)
+      delay = reschedule_delay(pending, min_interval, max_interval)
       record_poll!(pending_by_branch, sealed_by_branch, token, next_poll_at: delay.seconds.from_now)
       self.class.set(wait: delay.seconds)
         .perform_later(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval, token)
     end
 
     private
+
+    # Adaptive poll cadence: scale the wait with the number of pending children,
+    # clamped to [min_interval, max_interval]. min_interval <= max_interval is
+    # enforced up front in merge_branches, so the clamp can't raise here.
+    def reschedule_delay(pending, min_interval, max_interval)
+      (pending * FACTOR).clamp(min_interval, max_interval)
+    end
 
     # A poller is superseded when its token no longer matches what's stored on the
     # branch logs (a newer merge_branches pass rotated it). A plain read is enough
@@ -112,7 +119,18 @@ module ChronoForge
           .find_each do |child|
             # Intentionally uses the GUARDED perform_later (single-child path),
             # unlike the bulk perform_all_later bypass in dispatch_children.
+            #
+            # Rekick is best-effort recovery, so one bad child must never sink the
+            # poll: a raise here (e.g. cross-version kwarg drift failing the enqueue
+            # guard) would abort the whole run and — since it isn't a transient AR
+            # error — dead-letter the poller, orphaning every healthy sibling. Catch
+            # per child, log, and let the next poll retry it (it's still idle+stale).
             child.job_klass.perform_later(child.key, **child.kwargs.symbolize_keys)
+          rescue => e
+            Rails.logger.error do
+              "ChronoForge:BranchMergeJob rekick failed for child #{child.key}: " \
+              "#{e.class}: #{e.message}"
+            end
           end
       end
     end

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -5,6 +5,12 @@ module ChronoForge
   # no lock, does no replay, and carries no context. It exists so the heavy parent
   # workflow is replayed only twice per merge (kick off + completion wake).
   class BranchMergeJob < ActiveJob::Base
+    # The poller is the SOLE wake mechanism for a parked merge — a transient error
+    # (DB blip, etc.) before the reschedule below would otherwise orphan the parent
+    # in :idle (indistinguishable from never-started, invisible to recovery scans).
+    # Retry transient failures with backoff so the poll chain survives.
+    retry_on StandardError, wait: :polynomially_longer, attempts: 25
+
     CAP = 5_000          # cap the pending count; beyond it we just pick max_interval
     FACTOR = 0.06        # seconds of delay per pending child
     REKICK_AFTER = 5.minutes
@@ -13,8 +19,8 @@ module ChronoForge
     def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
       raise ArgumentError, "branch_log_ids must not be empty" if branch_log_ids.empty?
 
-      pending = branch_log_ids.sum { |id| incomplete_scope(id).limit(CAP).count }
-      sealed = branch_log_ids.all? { |id| branch_sealed?(id) }
+      pending = branch_log_ids.sum { |id| BranchProbe.incomplete(id).limit(CAP).count }
+      sealed = branch_log_ids.all? { |id| BranchProbe.sealed?(id) }
 
       if sealed && pending.zero?
         parent_job_class.constantize.perform_later(parent_key)
@@ -30,17 +36,6 @@ module ChronoForge
 
     private
 
-    # Anything not :completed counts as incomplete (Option A): failed/stalled
-    # children intentionally keep the parent parked until the user recovers them.
-    def incomplete_scope(branch_log_id)
-      Workflow.where(parent_execution_log_id: branch_log_id)
-        .where.not(state: Workflow.states[:completed])
-    end
-
-    def branch_sealed?(branch_log_id)
-      ExecutionLog.where(id: branch_log_id, state: ExecutionLog.states[:completed]).exists?
-    end
-
     # A child that was dispatched but never picked up (its job was dropped by the
     # backend) sits in :idle forever — note branch children keep started_at nil
     # their whole life (the executor only sets started_at when it CREATES the row,
@@ -55,6 +50,8 @@ module ChronoForge
           .where("updated_at < ?", REKICK_AFTER.ago)
           .limit(REKICK_BATCH)
           .find_each do |child|
+            # Intentionally uses the GUARDED perform_later (single-child path),
+            # unlike the bulk perform_all_later bypass in dispatch_children.
             child.job_klass.perform_later(child.key, **child.kwargs.symbolize_keys)
           end
       end

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -10,6 +10,11 @@ module ChronoForge
     # in :idle (indistinguishable from never-started, invisible to recovery scans).
     # Retry transient failures with backoff so the poll chain survives.
     retry_on StandardError, wait: :polynomially_longer, attempts: 25
+    # An empty branch_log_ids is a caller bug, not a transient fault — don't retry it.
+    # MUST be declared AFTER retry_on: ActiveSupport::Rescuable matches handlers in
+    # reverse registration order (last wins), not by specificity — so this overrides
+    # the broad retry_on StandardError above for ArgumentError specifically.
+    discard_on ArgumentError
 
     CAP = 5_000          # cap the pending count; beyond it we just pick max_interval
     FACTOR = 0.06        # seconds of delay per pending child

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -21,8 +21,15 @@ module ChronoForge
     REKICK_AFTER = 5.minutes
     REKICK_BATCH = 200   # bound per-run rekicks; later polls handle the rest
 
-    def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+    def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval, token = nil)
       raise ArgumentError, "branch_log_ids must not be empty" if branch_log_ids.empty?
+
+      # Fencing: every merge_branches pass mints a fresh token and writes it onto
+      # the branch logs, so a poller from a superseded chain (parent replay /
+      # re-enqueue) holds a stale token. It stops quietly — no poll, no wake, no
+      # reschedule — leaving only the newest chain to drive the merge. (A nil token
+      # is a pre-upgrade job enqueued before fencing existed; it runs unfenced.)
+      return if superseded?(branch_log_ids, token)
 
       # Per-branch probe (kept as maps so we can persist each branch's own state,
       # not just the merge aggregate). Same query count as a plain sum/all?.
@@ -32,7 +39,7 @@ module ChronoForge
       sealed = sealed_by_branch.values.all?
 
       if sealed && pending.zero?
-        record_poll!(pending_by_branch, sealed_by_branch, next_poll_at: nil)
+        record_poll!(pending_by_branch, sealed_by_branch, token, next_poll_at: nil)
         parent_job_class.constantize.perform_later(parent_key)
         return
       end
@@ -40,12 +47,21 @@ module ChronoForge
       rekick_dropped_jobs(branch_log_ids)
 
       delay = (pending * FACTOR).clamp(min_interval, max_interval)
-      record_poll!(pending_by_branch, sealed_by_branch, next_poll_at: delay.seconds.from_now)
+      record_poll!(pending_by_branch, sealed_by_branch, token, next_poll_at: delay.seconds.from_now)
       self.class.set(wait: delay.seconds)
-        .perform_later(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+        .perform_later(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval, token)
     end
 
     private
+
+    # A poller is superseded when its token no longer matches what's stored on the
+    # branch logs (a newer merge_branches pass rotated it). A plain read is enough
+    # for the early-out; the persisting write in record_poll! re-checks the token
+    # under a row lock so it can never clobber the newer chain.
+    def superseded?(branch_log_ids, token)
+      logs = ExecutionLog.where(id: branch_log_ids).to_a
+      logs.empty? || logs.any? { |log| log.metadata&.dig("poll_token") != token }
+    end
 
     # ActiveJob exposes no portable API to enumerate enqueued/scheduled jobs, so a
     # poller in the backend's scheduled set is invisible to a backend-agnostic
@@ -55,18 +71,25 @@ module ChronoForge
     # work still pending is the signal that the poller was dropped). This is purely
     # observational — replay and correctness never read it. It writes a "poll"
     # sub-key, leaving spawn_each's "cursors" metadata untouched.
-    def record_poll!(pending_by_branch, sealed_by_branch, next_poll_at:)
+    def record_poll!(pending_by_branch, sealed_by_branch, token, next_poll_at:)
       now = Time.current
       ExecutionLog.where(id: pending_by_branch.keys).find_each do |log|
-        meta = log.metadata || {}
-        meta["poll"] = {
-          "last_polled_at" => now.iso8601,
-          "next_poll_at" => next_poll_at&.iso8601,
-          "pending" => pending_by_branch[log.id],
-          "sealed" => sealed_by_branch[log.id],
-          "polls" => meta.dig("poll", "polls").to_i + 1
-        }
-        log.update!(metadata: meta)
+        # Lock the row so this read-modify-write can't clobber a concurrent token
+        # rotation (merge_branches) or another poller's metadata write — both touch
+        # the same JSON column. Re-check the token under the lock and skip if we've
+        # been superseded mid-run, so a stale poller never overwrites the fence.
+        log.with_lock do
+          meta = log.metadata || {}
+          next unless meta["poll_token"] == token
+          meta["poll"] = {
+            "last_polled_at" => now.iso8601,
+            "next_poll_at" => next_poll_at&.iso8601,
+            "pending" => pending_by_branch[log.id],
+            "sealed" => sealed_by_branch[log.id],
+            "polls" => meta.dig("poll", "polls").to_i + 1
+          }
+          log.update!(metadata: meta)
+        end
       end
     end
 

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -5,16 +5,16 @@ module ChronoForge
   # no lock, does no replay, and carries no context. It exists so the heavy parent
   # workflow is replayed only twice per merge (kick off + completion wake).
   class BranchMergeJob < ActiveJob::Base
-    # The poller is the SOLE wake mechanism for a parked merge — a transient error
-    # (DB blip, etc.) before the reschedule below would otherwise orphan the parent
-    # in :idle (indistinguishable from never-started, invisible to recovery scans).
-    # Retry transient failures with backoff so the poll chain survives.
-    retry_on StandardError, wait: :polynomially_longer, attempts: 25
-    # An empty branch_log_ids is a caller bug, not a transient fault — don't retry it.
-    # MUST be declared AFTER retry_on: ActiveSupport::Rescuable matches handlers in
-    # reverse registration order (last wins), not by specificity — so this overrides
-    # the broad retry_on StandardError above for ArgumentError specifically.
-    discard_on ArgumentError
+    # The poller is the parent's only wake mechanism, so survive TRANSIENT
+    # infrastructure errors (DB connection/timeout/deadlock) with backoff. Any
+    # other error — a programming bug, a bad guard — is NOT retried: it propagates
+    # to the backend's failed-job queue where it's visible, rather than being
+    # silently retried-then-discarded (which would orphan the parent in :idle).
+    retry_on ActiveRecord::ConnectionNotEstablished,
+      ActiveRecord::ConnectionTimeoutError,
+      ActiveRecord::Deadlocked,
+      ActiveRecord::LockWaitTimeout,
+      wait: :polynomially_longer, attempts: 25
 
     CAP = 5_000          # cap the pending count; beyond it we just pick max_interval
     FACTOR = 0.06        # seconds of delay per pending child

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -8,8 +8,11 @@ module ChronoForge
     CAP = 5_000          # cap the pending count; beyond it we just pick max_interval
     FACTOR = 0.06        # seconds of delay per pending child
     REKICK_AFTER = 5.minutes
+    REKICK_BATCH = 200   # bound per-run rekicks; later polls handle the rest
 
     def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+      raise ArgumentError, "branch_log_ids must not be empty" if branch_log_ids.empty?
+
       pending = branch_log_ids.sum { |id| incomplete_scope(id).limit(CAP).count }
       sealed = branch_log_ids.all? { |id| branch_sealed?(id) }
 
@@ -27,6 +30,8 @@ module ChronoForge
 
     private
 
+    # Anything not :completed counts as incomplete (Option A): failed/stalled
+    # children intentionally keep the parent parked until the user recovers them.
     def incomplete_scope(branch_log_id)
       Workflow.where(parent_execution_log_id: branch_log_id)
         .where.not(state: Workflow.states[:completed])
@@ -36,15 +41,19 @@ module ChronoForge
       ExecutionLog.where(id: branch_log_id, state: ExecutionLog.states[:completed]).exists?
     end
 
-    # A child dispatched but never run (its job was dropped by the backend) is
-    # re-enqueued. started_at IS NULL can't distinguish "never enqueued" from
-    # "queued but not yet picked up", so we only re-kick children that have been
-    # idle past REKICK_AFTER. Re-enqueue is idempotent: a completed/running child
-    # no-ops via the executable?/lock guard.
+    # A child that was dispatched but never picked up (its job was dropped by the
+    # backend) sits in :idle forever — note branch children keep started_at nil
+    # their whole life (the executor only sets started_at when it CREATES the row,
+    # but branch children are pre-inserted), so :idle, not started_at, is the
+    # "never ran" signal. We only re-kick :idle children idle past REKICK_AFTER
+    # (a running child must never be re-dispatched; a failed/stalled child needs
+    # operator recovery). Re-enqueue of an :idle child a worker just grabbed is
+    # still safe — the lock guard rejects the duplicate. Capped per run.
     def rekick_dropped_jobs(branch_log_ids)
       branch_log_ids.each do |id|
-        Workflow.where(parent_execution_log_id: id, started_at: nil)
+        Workflow.where(parent_execution_log_id: id, state: Workflow.states[:idle])
           .where("updated_at < ?", REKICK_AFTER.ago)
+          .limit(REKICK_BATCH)
           .find_each do |child|
             child.job_klass.perform_later(child.key, **child.kwargs.symbolize_keys)
           end

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -24,22 +24,51 @@ module ChronoForge
     def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
       raise ArgumentError, "branch_log_ids must not be empty" if branch_log_ids.empty?
 
-      pending = branch_log_ids.sum { |id| BranchProbe.incomplete(id).limit(CAP).count }
-      sealed = branch_log_ids.all? { |id| BranchProbe.sealed?(id) }
+      # Per-branch probe (kept as maps so we can persist each branch's own state,
+      # not just the merge aggregate). Same query count as a plain sum/all?.
+      pending_by_branch = branch_log_ids.to_h { |id| [id, BranchProbe.incomplete(id).limit(CAP).count] }
+      sealed_by_branch = branch_log_ids.to_h { |id| [id, BranchProbe.sealed?(id)] }
+      pending = pending_by_branch.values.sum
+      sealed = sealed_by_branch.values.all?
 
       if sealed && pending.zero?
+        record_poll!(pending_by_branch, sealed_by_branch, next_poll_at: nil)
         parent_job_class.constantize.perform_later(parent_key)
         return
       end
 
       rekick_dropped_jobs(branch_log_ids)
 
-      delay = [[pending * FACTOR, min_interval].max, max_interval].min
+      delay = (pending * FACTOR).clamp(min_interval, max_interval)
+      record_poll!(pending_by_branch, sealed_by_branch, next_poll_at: delay.seconds.from_now)
       self.class.set(wait: delay.seconds)
         .perform_later(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
     end
 
     private
+
+    # ActiveJob exposes no portable API to enumerate enqueued/scheduled jobs, so a
+    # poller in the backend's scheduled set is invisible to a backend-agnostic
+    # dashboard. We make the durable log the source of truth instead: each poll
+    # stamps its observable state onto every target branch log's metadata, so the
+    # dashboard can list in-flight merges (and a next_poll_at long in the past with
+    # work still pending is the signal that the poller was dropped). This is purely
+    # observational — replay and correctness never read it. It writes a "poll"
+    # sub-key, leaving spawn_each's "cursors" metadata untouched.
+    def record_poll!(pending_by_branch, sealed_by_branch, next_poll_at:)
+      now = Time.current
+      ExecutionLog.where(id: pending_by_branch.keys).find_each do |log|
+        meta = log.metadata || {}
+        meta["poll"] = {
+          "last_polled_at" => now.iso8601,
+          "next_poll_at" => next_poll_at&.iso8601,
+          "pending" => pending_by_branch[log.id],
+          "sealed" => sealed_by_branch[log.id],
+          "polls" => meta.dig("poll", "polls").to_i + 1
+        }
+        log.update!(metadata: meta)
+      end
+    end
 
     # A child that was dispatched but never picked up (its job was dropped by the
     # backend) sits :idle with started_at nil. setup_workflow! stamps started_at

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -42,16 +42,19 @@ module ChronoForge
     private
 
     # A child that was dispatched but never picked up (its job was dropped by the
-    # backend) sits in :idle forever — note branch children keep started_at nil
-    # their whole life (the executor only sets started_at when it CREATES the row,
-    # but branch children are pre-inserted), so :idle, not started_at, is the
-    # "never ran" signal. We only re-kick :idle children idle past REKICK_AFTER
-    # (a running child must never be re-dispatched; a failed/stalled child needs
-    # operator recovery). Re-enqueue of an :idle child a worker just grabbed is
-    # still safe — the lock guard rejects the duplicate. Capped per run.
+    # backend) sits :idle with started_at nil. setup_workflow! stamps started_at
+    # on a child's first execution, so a nil started_at precisely means "never
+    # ran" — that's what we rekick on. It correctly excludes a child that ran and
+    # is now parked on a wait/wait_until (also :idle, but started_at is set):
+    # rekicking that would re-evaluate the wait condition prematurely and pile up
+    # duplicate scheduled jobs. We also require the row to be stale past
+    # REKICK_AFTER (a freshly dispatched child just hasn't been grabbed yet) and
+    # keep the :idle guard (a running/failed/stalled child must never be
+    # re-dispatched). Re-enqueue of an :idle child a worker just grabbed is still
+    # safe — the lock guard rejects the duplicate. Capped per run.
     def rekick_dropped_jobs(branch_log_ids)
       branch_log_ids.each do |id|
-        Workflow.where(parent_execution_log_id: id, state: Workflow.states[:idle])
+        Workflow.where(parent_execution_log_id: id, state: Workflow.states[:idle], started_at: nil)
           .where("updated_at < ?", REKICK_AFTER.ago)
           .limit(REKICK_BATCH)
           .find_each do |child|

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module ChronoForge
+  # Lightweight poller that joins one or more branches. NOT a workflow — it holds
+  # no lock, does no replay, and carries no context. It exists so the heavy parent
+  # workflow is replayed only twice per merge (kick off + completion wake).
+  class BranchMergeJob < ActiveJob::Base
+    CAP = 5_000          # cap the pending count; beyond it we just pick max_interval
+    FACTOR = 0.06        # seconds of delay per pending child
+    REKICK_AFTER = 5.minutes
+
+    def perform(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+      pending = branch_log_ids.sum { |id| incomplete_scope(id).limit(CAP).count }
+      sealed = branch_log_ids.all? { |id| branch_sealed?(id) }
+
+      if sealed && pending.zero?
+        parent_job_class.constantize.perform_later(parent_key)
+        return
+      end
+
+      rekick_dropped_jobs(branch_log_ids)
+
+      delay = [[pending * FACTOR, min_interval].max, max_interval].min
+      self.class.set(wait: delay.seconds)
+        .perform_later(parent_key, parent_job_class, branch_log_ids, min_interval, max_interval)
+    end
+
+    private
+
+    def incomplete_scope(branch_log_id)
+      Workflow.where(parent_execution_log_id: branch_log_id)
+        .where.not(state: Workflow.states[:completed])
+    end
+
+    def branch_sealed?(branch_log_id)
+      ExecutionLog.where(id: branch_log_id, state: ExecutionLog.states[:completed]).exists?
+    end
+
+    # A child dispatched but never run (its job was dropped by the backend) is
+    # re-enqueued. started_at IS NULL can't distinguish "never enqueued" from
+    # "queued but not yet picked up", so we only re-kick children that have been
+    # idle past REKICK_AFTER. Re-enqueue is idempotent: a completed/running child
+    # no-ops via the executable?/lock guard.
+    def rekick_dropped_jobs(branch_log_ids)
+      branch_log_ids.each do |id|
+        Workflow.where(parent_execution_log_id: id, started_at: nil)
+          .where("updated_at < ?", REKICK_AFTER.ago)
+          .find_each do |child|
+            child.job_klass.perform_later(child.key, **child.kwargs.symbolize_keys)
+          end
+      end
+    end
+  end
+end

--- a/lib/chrono_forge/branch_probe.rb
+++ b/lib/chrono_forge/branch_probe.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module ChronoForge
+  # Single source of truth for "is this branch done?" — used by both merge_branches
+  # (boolean) and BranchMergeJob (which needs the sealed flag and pending count
+  # separately for its adaptive poll cadence). Option A: only :completed counts as
+  # done, so a failed/stalled child keeps the branch pending until recovered.
+  module BranchProbe
+    module_function
+
+    # The branch's coordination log is sealed (fully dispatched).
+    def sealed?(branch_log_id)
+      ExecutionLog.where(id: branch_log_id, state: ExecutionLog.states[:completed]).exists?
+    end
+
+    # Relation of this branch's children that are not yet completed.
+    def incomplete(branch_log_id)
+      Workflow.where(parent_execution_log_id: branch_log_id)
+        .where.not(state: Workflow.states[:completed])
+    end
+
+    def done?(branch_log_id)
+      sealed?(branch_log_id) && !incomplete(branch_log_id).exists?
+    end
+  end
+end

--- a/lib/chrono_forge/cleanup.rb
+++ b/lib/chrono_forge/cleanup.rb
@@ -93,6 +93,12 @@ module ChronoForge
         ids = batch.ids
         next if ids.empty?
 
+        # Branch children point at their parent's branch$ execution log via
+        # parent_execution_log_id. Bulk delete bypasses the dependent: :nullify callback,
+        # so nullify explicitly to avoid dangling references when a parent is reclaimed.
+        Workflow.where(parent_execution_log_id: ExecutionLog.where(workflow_id: ids).select(:id))
+          .update_all(parent_execution_log_id: nil)
+
         # Delete dependent rows in bulk rather than relying on row-by-row
         # dependent: :destroy callbacks.
         result[:execution_logs] += ExecutionLog.where(workflow_id: ids).delete_all

--- a/lib/chrono_forge/execution_log.rb
+++ b/lib/chrono_forge/execution_log.rb
@@ -33,6 +33,12 @@ module ChronoForge
 
     belongs_to :workflow
 
+    has_many :spawned_workflows,
+      class_name: "ChronoForge::Workflow",
+      foreign_key: :parent_execution_log_id,
+      inverse_of: :parent_execution_log,
+      dependent: :nullify
+
     enum :state, %i[
       pending
       completed

--- a/lib/chrono_forge/executor.rb
+++ b/lib/chrono_forge/executor.rb
@@ -14,6 +14,14 @@ module ChronoForge
 
     class InvalidStepName < NotExecutableError; end
 
+    # spawn/spawn_each called outside a branch block. NotExecutableError so it
+    # propagates (fail-fast on a programming error) rather than being retried.
+    class NotInBranchError < NotExecutableError; end
+
+    # A branch was opened but neither merged via merge_branches nor declared
+    # automerge: true. Raised at the completion gate. Fail-fast (not retried).
+    class UnmergedBranchError < NotExecutableError; end
+
     # "$" separates the segments of a step name (e.g. "durably_repeat$name$ts").
     # User-supplied names/methods must not contain it.
     STEP_NAME_DELIMITER = "$"

--- a/lib/chrono_forge/executor.rb
+++ b/lib/chrono_forge/executor.rb
@@ -198,6 +198,15 @@ module ChronoForge
           workflow.kwargs = kwargs
           workflow.started_at = Time.current
         end
+
+      # Branch children are pre-inserted by their parent (dispatch_children's
+      # insert_all), so the creation block above never runs for them and their
+      # started_at stays nil. Stamp it the first time the child actually executes
+      # so started_at reliably means "has been picked up and run" — the
+      # BranchMergeJob rekick poller treats a nil started_at as a never-executed
+      # (dropped) child, and must not mistake a child that ran and is now parked
+      # on a wait (also :idle) for one that was never picked up.
+      @workflow.update_column(:started_at, Time.current) if @workflow.started_at.nil?
     end
 
     def setup_context!

--- a/lib/chrono_forge/executor.rb
+++ b/lib/chrono_forge/executor.rb
@@ -22,6 +22,10 @@ module ChronoForge
     # automerge: true. Raised at the completion gate. Fail-fast (not retried).
     class UnmergedBranchError < NotExecutableError; end
 
+    # merge_branches given a name that was never opened as a branch this pass.
+    # NotExecutableError so it propagates (fail-fast) instead of being retried.
+    class UnknownBranchError < NotExecutableError; end
+
     # "$" separates the segments of a step name (e.g. "durably_repeat$name$ts").
     # User-supplied names/methods must not contain it.
     STEP_NAME_DELIMITER = "$"
@@ -150,7 +154,7 @@ module ChronoForge
         # Graceful handling of concurrent execution
         Rails.logger.warn { "ChronoForge:#{self.class}(#{key}) concurrent execution detected" }
         nil
-      rescue NotExecutableError, ArgumentError
+      rescue NotExecutableError
         raise
       rescue => e
         Rails.logger.error { "ChronoForge:#{self.class}(#{key}) workflow execution failed" }

--- a/lib/chrono_forge/executor.rb
+++ b/lib/chrono_forge/executor.rb
@@ -150,7 +150,7 @@ module ChronoForge
         # Graceful handling of concurrent execution
         Rails.logger.warn { "ChronoForge:#{self.class}(#{key}) concurrent execution detected" }
         nil
-      rescue NotExecutableError
+      rescue NotExecutableError, ArgumentError
         raise
       rescue => e
         Rails.logger.error { "ChronoForge:#{self.class}(#{key}) workflow execution failed" }

--- a/lib/chrono_forge/executor/methods.rb
+++ b/lib/chrono_forge/executor/methods.rb
@@ -6,6 +6,8 @@ module ChronoForge
       include Methods::ContinueIf
       include Methods::DurablyExecute
       include Methods::DurablyRepeat
+      include Methods::Branch
+      include Methods::MergeBranches
       include Methods::WorkflowStates
     end
   end

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -64,17 +64,19 @@ module ChronoForge
             if source.order_values.present?
               raise NotExecutableError,
                 "spawn_each iterates #{source.model_name} by primary key; remove the " \
-                "explicit .order(...) from the source relation"
+                "explicit .order(...) (or default-scope order) from the source relation"
             end
             source.find_in_batches(batch_size: of, start: cursor["pk"]) do |records|
               entries = records.map do |record|
                 klass, kw = normalize_spawn(yield(record))
-                ck = "#{@workflow.key}$#{cb[:name]}$#{name}_#{n}"
-                n += 1
+                # Stable per-record key: an inclusive find_in_batches re-yield of the
+                # boundary record on crash-resume produces the SAME key, so insert_all
+                # dedups it (idempotent). Sequential indexing would duplicate it.
+                ck = "#{@workflow.key}$#{cb[:name]}$#{name}_#{record.id}"
                 [ck, klass, kw]
               end
               dispatch_children(cb, entries)
-              advance_cursor!(cb, name, pk: records.last.id, n: n)
+              advance_cursor!(cb, name, pk: records.last.id)
             end
           else
             source.drop(n).each_slice(of) do |slice|
@@ -132,11 +134,11 @@ module ChronoForge
         # Advance (and persist) a spawn_each cursor on the branch log.
         # `n` is the running item index; `pk` is the AR keyset position (nil for
         # plain enumerables). (Used by spawn_each in a later task.)
-        def advance_cursor!(cb, spawn_name, n:, pk: nil)
+        def advance_cursor!(cb, spawn_name, n: nil, pk: nil)
           meta = cb[:log].metadata || {}
           cursors = meta["cursors"] || {}
           entry = cursors[spawn_name.to_s] || {}
-          entry["n"] = n
+          entry["n"] = n unless n.nil?
           entry["pk"] = pk unless pk.nil?
           cursors[spawn_name.to_s] = entry
           meta["cursors"] = cursors
@@ -146,6 +148,10 @@ module ChronoForge
         # Normalize a spawn_each block return: [Klass, kwargs] or a bare Klass.
         def normalize_spawn(result)
           klass, kwargs = Array(result)
+          unless klass.is_a?(Module)
+            raise ArgumentError,
+              "spawn_each block must return a workflow class or [class, kwargs] (got #{result.inspect})"
+          end
           [klass, kwargs || {}]
         end
       end

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -24,7 +24,7 @@ module ChronoForge
           # enumeration in spawn_each never re-runs after sealing. Do not move
           # dispatch out from behind this guard.
           unless log.completed?
-            @current_branch = {name: name.to_s, log: log, seq: 0}
+            @current_branch = {name: name.to_s, log: log}
             begin
               yield
             ensure

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -60,8 +60,8 @@ module ChronoForge
         def spawn_each(name, source, of: 1000)
           cb = current_branch!
           validate_step_name_segment!(name)
-          cursor = (cb[:log].metadata&.dig("cursors", name.to_s)) || {}
-          n = (cursor["n"] || 0)
+          cursor = cb[:log].metadata&.dig("cursors", name.to_s) || {}
+          n = cursor["n"] || 0
 
           if source.is_a?(ActiveRecord::Relation)
             # spawn_each iterates by primary key (find_in_batches) so the stream

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -139,6 +139,8 @@ module ChronoForge
           ActiveJob.perform_all_later(jobs) if jobs.any?
         end
 
+        # Mirrors the class-level __validate_enqueue! (executor.rb) because
+        # perform_all_later bypasses that guard — the two must stay in sync.
         def validate_child_enqueue!(child_key, kwargs)
           unless child_key.is_a?(String)
             raise ArgumentError, "child key must be a String (got #{child_key.inspect})"

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -53,10 +53,15 @@ module ChronoForge
         end
 
         # Dispatch one child per item of `source`, streamed. AR relations use
-        # keyset iteration (find_in_batches start:) for constant memory; any other
-        # enumerable uses an offset cursor. Items are keyed `name_{index}` by their
-        # sequential position, so the source must re-enumerate identically across
-        # replays. The block returns [WorkflowClass, kwargs] (or a bare class).
+        # keyset iteration (find_in_batches start:) for constant memory and are
+        # keyed by record id; any other enumerable uses an offset cursor and is
+        # keyed `name_{index}` by position. Either way the source must re-enumerate
+        # identically across replays. For AR sources that additionally means STABLE
+        # MEMBERSHIP: dispatch resumes from the last primary key on crash-recovery,
+        # so a row entering the relation below the cursor after it passed (e.g. a
+        # mutating `where(state:)` scope) never gets a child — point spawn_each at a
+        # set fixed for the branch's lifetime. The block returns [WorkflowClass,
+        # kwargs] (or a bare class).
         def spawn_each(name, source, of: 1000)
           cb = current_branch!
           validate_step_name_segment!(name)

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -33,6 +33,13 @@ module ChronoForge
             log.update!(state: :completed, completed_at: Time.current)
           end
 
+          # automerge joins the branch inline, the moment its block closes (eager
+          # dispatch + immediate await). Deferred/concurrent joins use an explicit
+          # merge_branches instead. Runs on every pass so replay re-checks via the
+          # merge$<name> log's own idempotency; the inline merge removes the branch
+          # from @open_branches on completion, so the completion gate won't see it.
+          merge_branches(name) if automerge
+
           name
         end
 

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -45,6 +45,52 @@ module ChronoForge
           name
         end
 
+        # Dispatch one child per item of `source`, streamed. AR relations use
+        # keyset iteration (find_in_batches start:) for constant memory; any other
+        # enumerable uses an offset cursor. Items are keyed `name_{index}` by their
+        # sequential position, so the source must re-enumerate identically across
+        # replays. The block returns [WorkflowClass, kwargs] (or a bare class).
+        def spawn_each(name, source, of: 1000)
+          cb = current_branch!
+          validate_step_name_segment!(name)
+          cursor = (cb[:log].metadata&.dig("cursors", name.to_s)) || {}
+          n = (cursor["n"] || 0)
+
+          if source.is_a?(ActiveRecord::Relation)
+            # spawn_each iterates by primary key (find_in_batches) so the stream
+            # re-enumerates identically across replays. An explicit .order would
+            # make iteration non-deterministic, so reject it up front with a clear
+            # error rather than letting find_in_batches raise deep in the loop.
+            if source.order_values.present?
+              raise NotExecutableError,
+                "spawn_each iterates #{source.model_name} by primary key; remove the " \
+                "explicit .order(...) from the source relation"
+            end
+            source.find_in_batches(batch_size: of, start: cursor["pk"]) do |records|
+              entries = records.map do |record|
+                klass, kw = normalize_spawn(yield(record))
+                ck = "#{@workflow.key}$#{cb[:name]}$#{name}_#{n}"
+                n += 1
+                [ck, klass, kw]
+              end
+              dispatch_children(cb, entries)
+              advance_cursor!(cb, name, pk: records.last.id, n: n)
+            end
+          else
+            source.drop(n).each_slice(of) do |slice|
+              entries = slice.map do |item|
+                klass, kw = normalize_spawn(yield(item))
+                ck = "#{@workflow.key}$#{cb[:name]}$#{name}_#{n}"
+                n += 1
+                [ck, klass, kw]
+              end
+              dispatch_children(cb, entries)
+              advance_cursor!(cb, name, n: n)
+            end
+          end
+          name
+        end
+
         private
 
         def current_branch!
@@ -95,6 +141,12 @@ module ChronoForge
           cursors[spawn_name.to_s] = entry
           meta["cursors"] = cursors
           cb[:log].update!(metadata: meta)
+        end
+
+        # Normalize a spawn_each block return: [Klass, kwargs] or a bare Klass.
+        def normalize_spawn(result)
+          klass, kwargs = Array(result)
+          [klass, kwargs || {}]
         end
       end
     end

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -1,0 +1,102 @@
+module ChronoForge
+  module Executor
+    module Methods
+      module Branch
+        # Opens a named branch — a durable fan-out step. Spawns inside the block
+        # eagerly create + enqueue child workflows; the branch SEALS when the
+        # block closes. Returns without waiting (branches are concurrent; the
+        # join is a separate merge_branches / automerge).
+        def branch(name, automerge: false)
+          raise ArgumentError, "branch requires a block" unless block_given?
+          raise ArgumentError, "branch blocks cannot be nested" if @current_branch
+          validate_step_name_segment!(name)
+
+          step_name = "branch$#{name}"
+          log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }
+
+          # The sealed branch log may be a readonly, id-less cache stand-in; fetch
+          # the real id so the registry/merge can scope children to it.
+          log_id = log.id || ExecutionLog.where(workflow: @workflow, step_name: step_name).pick(:id)
+          (@open_branches ||= {})[name.to_s] = {automerge: automerge, log_id: log_id}
+
+          # ---- THE single most important correctness/performance property ----
+          # A SEALED branch skips its block ENTIRELY. The expensive source
+          # enumeration in spawn_each never re-runs after sealing. Do not move
+          # dispatch out from behind this guard.
+          unless log.completed?
+            @current_branch = {name: name.to_s, log: log, seq: 0}
+            begin
+              yield
+            ensure
+              @current_branch = nil
+            end
+            log.update!(state: :completed, completed_at: Time.current)
+          end
+
+          name
+        end
+
+        # Dispatch a single child into the current branch.
+        def spawn(name, workflow_class, **kwargs)
+          cb = current_branch!
+          validate_step_name_segment!(name)
+          child_key = "#{@workflow.key}$#{cb[:name]}$#{name}"
+          dispatch_children(cb, [[child_key, workflow_class, kwargs]])
+          name
+        end
+
+        private
+
+        def current_branch!
+          @current_branch || raise(NotInBranchError, "spawn/spawn_each may only be called inside a branch block")
+        end
+
+        # Bulk-create child workflow rows then bulk-enqueue their jobs.
+        # perform_all_later bypasses the class-level perform_later guard, so we
+        # validate the args ourselves before enqueuing.
+        def dispatch_children(cb, entries)
+          return if entries.empty?
+          now = Time.current
+          rows = entries.map do |child_key, klass, kwargs|
+            validate_child_enqueue!(child_key, kwargs)
+            {
+              key: child_key, job_class: klass.to_s,
+              kwargs: kwargs, options: {}, context: {},
+              state: Workflow.states[:idle],
+              parent_execution_log_id: cb[:log].id,
+              created_at: now, updated_at: now
+            }
+          end
+          # On-conflict-ignore makes re-dispatch (crash recovery) idempotent.
+          Workflow.insert_all(rows, unique_by: [:job_class, :key])
+          jobs = entries.map { |child_key, klass, kwargs| klass.new(child_key, **kwargs) }
+          ActiveJob.perform_all_later(jobs)
+        end
+
+        def validate_child_enqueue!(child_key, kwargs)
+          unless child_key.is_a?(String)
+            raise ArgumentError, "child key must be a String (got #{child_key.inspect})"
+          end
+          reserved = kwargs.keys.map(&:to_sym) & RESERVED_KWARGS
+          if reserved.any?
+            raise ArgumentError, "#{reserved.join(", ")} are reserved ChronoForge keywords"
+          end
+        end
+
+        # Advance (and persist) a spawn_each cursor on the branch log.
+        # `n` is the running item index; `pk` is the AR keyset position (nil for
+        # plain enumerables). (Used by spawn_each in a later task.)
+        def advance_cursor!(cb, spawn_name, n:, pk: nil)
+          meta = cb[:log].metadata || {}
+          cursors = meta["cursors"] || {}
+          entry = cursors[spawn_name.to_s] || {}
+          entry["n"] = n
+          entry["pk"] = pk unless pk.nil?
+          cursors[spawn_name.to_s] = entry
+          meta["cursors"] = cursors
+          cb[:log].update!(metadata: meta)
+        end
+      end
+    end
+  end
+end

--- a/lib/chrono_forge/executor/methods/branch.rb
+++ b/lib/chrono_forge/executor/methods/branch.rb
@@ -124,8 +124,19 @@ module ChronoForge
           end
           # On-conflict-ignore makes re-dispatch (crash recovery) idempotent.
           Workflow.insert_all(rows, unique_by: [:job_class, :key])
-          jobs = entries.map { |child_key, klass, kwargs| klass.new(child_key, **kwargs) }
-          ActiveJob.perform_all_later(jobs)
+
+          # Enqueue only children still :idle. On a crash-resume the boundary chunk
+          # is re-dispatched; its rows already exist (insert_all ignored them) and
+          # may already have run — re-enqueuing a completed/running child would only
+          # raise NotExecutableError and dead-letter. Freshly inserted rows are
+          # :idle (we enqueue after inserting, so no worker can have touched them),
+          # so first-time dispatch enqueues the whole batch.
+          keys = entries.map { |child_key, _klass, _kwargs| child_key }
+          idle = Workflow.where(key: keys, state: Workflow.states[:idle]).pluck(:key).to_set
+          jobs = entries.filter_map do |child_key, klass, kwargs|
+            klass.new(child_key, **kwargs) if idle.include?(child_key)
+          end
+          ActiveJob.perform_all_later(jobs) if jobs.any?
         end
 
         def validate_child_enqueue!(child_key, kwargs)

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -2,6 +2,58 @@ module ChronoForge
   module Executor
     module Methods
       module MergeBranches
+        # Join one or more named branches. Separate from dispatch so branches run
+        # concurrently. Does one immediate check; if not done, hands off to the
+        # lightweight BranchMergeJob and halts (the heavy parent is not replayed
+        # per poll). Cadence clamps between min/max, scaled by pending.
+        def merge_branches(*names, min_interval: 5.seconds, max_interval: 5.minutes)
+          step_name = "merge$#{names.map(&:to_s).sort.join(",")}"
+          log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }
+
+          if log.completed?
+            # Already done — remove from registry so the completion gate does not
+            # see these as unmerged, then skip.
+            names.each { |nm| @open_branches&.delete(nm.to_s) }
+            return
+          end
+
+          branch_log_ids = names.map { |nm| open_branch!(nm)[:log_id] }
+
+          if branches_done?(branch_log_ids)
+            names.each { |nm| @open_branches.delete(nm.to_s) }
+            log.update!(state: :completed, completed_at: Time.current)
+            return
+          end
+
+          enqueue_branch_merge_job(branch_log_ids, min_interval, max_interval)
+          halt_execution!
+        end
+        alias_method :merge_branch, :merge_branches
+
+        private
+
+        def open_branch!(name)
+          (@open_branches || {}).fetch(name.to_s) do
+            raise ArgumentError, "no open branch named #{name.inspect} (open it with `branch #{name.inspect} do … end` first)"
+          end
+        end
+
+        # A branch is done when its log is sealed (completed) and it has no
+        # incomplete children. exists? short-circuits at the first incomplete row.
+        def branches_done?(branch_log_ids)
+          branch_log_ids.all? do |id|
+            next false unless ExecutionLog.where(id: id, state: ExecutionLog.states[:completed]).exists?
+            !Workflow.where(parent_execution_log_id: id)
+              .where.not(state: Workflow.states[:completed]).exists?
+          end
+        end
+
+        def enqueue_branch_merge_job(branch_log_ids, min_interval, max_interval)
+          BranchMergeJob.perform_later(
+            @workflow.key, self.class.to_s, branch_log_ids,
+            min_interval.to_i, max_interval.to_i
+          )
+        end
       end
     end
   end

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -1,0 +1,8 @@
+module ChronoForge
+  module Executor
+    module Methods
+      module MergeBranches
+      end
+    end
+  end
+end

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -34,7 +34,7 @@ module ChronoForge
 
         def open_branch!(name)
           (@open_branches || {}).fetch(name.to_s) do
-            raise ArgumentError, "no open branch named #{name.inspect} (open it with `branch #{name.inspect} do … end` first)"
+            raise UnknownBranchError, "no open branch named #{name.inspect} (open it with `branch #{name.inspect} do … end` first)"
           end
         end
 

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -52,9 +52,20 @@ module ChronoForge
         end
 
         def enqueue_branch_merge_job(branch_log_ids, min_interval, max_interval)
+          # Mint a fresh fencing token and stamp it on each branch log under a row
+          # lock — the read-modify-write must not clobber a concurrent poll-state
+          # write from an in-flight poller. Rotating the token orphans any prior
+          # poller chain (its token no longer matches), so only the chain we enqueue
+          # below drives the merge. See BranchMergeJob#superseded?.
+          token = SecureRandom.uuid
+          ExecutionLog.where(id: branch_log_ids).find_each do |log|
+            log.with_lock do
+              log.update!(metadata: (log.metadata || {}).merge("poll_token" => token))
+            end
+          end
           BranchMergeJob.perform_later(
             @workflow.key, self.class.to_s, branch_log_ids,
-            min_interval.to_i, max_interval.to_i
+            min_interval.to_i, max_interval.to_i, token
           )
         end
       end

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -15,6 +15,15 @@ module ChronoForge
             end
           end
 
+          # Validate cadence here, in the parent, so a misconfiguration fails at the
+          # call site instead of deep inside the poller — where (pending * FACTOR)
+          # .clamp(min, max) would raise ArgumentError, a non-transient error that
+          # dead-letters BranchMergeJob and orphans the parent.
+          if min_interval > max_interval
+            raise ArgumentError,
+              "min_interval (#{min_interval}) must be <= max_interval (#{max_interval})"
+          end
+
           names = names.map(&:to_s).uniq
           step_name = "merge$#{names.sort.join(",")}"
           log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -7,6 +7,14 @@ module ChronoForge
         # lightweight BranchMergeJob and halts (the heavy parent is not replayed
         # per poll). Cadence clamps between min/max, scaled by pending.
         def merge_branches(*names, min_interval: 5.seconds, max_interval: 5.minutes)
+          names.each do |nm|
+            validate_step_name_segment!(nm)  # rejects "$"
+            if nm.to_s.include?(",")
+              raise InvalidStepName,
+                "branch name may not contain ',' (reserved merge separator): #{nm.inspect}"
+            end
+          end
+
           step_name = "merge$#{names.map(&:to_s).sort.join(",")}"
           log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }
 
@@ -20,7 +28,7 @@ module ChronoForge
           branch_log_ids = names.map { |nm| open_branch!(nm)[:log_id] }
 
           if branches_done?(branch_log_ids)
-            names.each { |nm| @open_branches.delete(nm.to_s) }
+            names.each { |nm| @open_branches&.delete(nm.to_s) }
             log.update!(state: :completed, completed_at: Time.current)
             return
           end

--- a/lib/chrono_forge/executor/methods/merge_branches.rb
+++ b/lib/chrono_forge/executor/methods/merge_branches.rb
@@ -15,7 +15,8 @@ module ChronoForge
             end
           end
 
-          step_name = "merge$#{names.map(&:to_s).sort.join(",")}"
+          names = names.map(&:to_s).uniq
+          step_name = "merge$#{names.sort.join(",")}"
           log = find_or_create_execution_log!(step_name) { |l| l.started_at = Time.current }
 
           if log.completed?
@@ -46,14 +47,8 @@ module ChronoForge
           end
         end
 
-        # A branch is done when its log is sealed (completed) and it has no
-        # incomplete children. exists? short-circuits at the first incomplete row.
         def branches_done?(branch_log_ids)
-          branch_log_ids.all? do |id|
-            next false unless ExecutionLog.where(id: id, state: ExecutionLog.states[:completed]).exists?
-            !Workflow.where(parent_execution_log_id: id)
-              .where.not(state: Workflow.states[:completed]).exists?
-          end
+          branch_log_ids.all? { |id| BranchProbe.done?(id) }
         end
 
         def enqueue_branch_merge_job(branch_log_ids, min_interval, max_interval)

--- a/lib/chrono_forge/executor/methods/workflow_states.rb
+++ b/lib/chrono_forge/executor/methods/workflow_states.rb
@@ -48,6 +48,8 @@ module ChronoForge
         # - Safe to call multiple times without side effects
         #
         def complete_workflow!
+          enforce_branch_joins!
+
           # Create an execution log for workflow completion
           execution_log = find_or_create_execution_log!("$workflow_completion$") do |log|
             log.started_at = Time.current
@@ -78,6 +80,20 @@ module ChronoForge
             )
             raise
           end
+        end
+
+        # Every branch must be joined: automerge branches join inline at their
+        # block's close (removing themselves from @open_branches); explicitly
+        # awaited branches are removed by merge_branches. Anything still in
+        # @open_branches here was opened but never joined — fail fast.
+        def enforce_branch_joins!
+          leftover = (@open_branches || {}).keys
+          return if leftover.empty?
+
+          raise UnmergedBranchError,
+            "branch(es) #{leftover.join(", ")} were opened but never merged. " \
+            "Add `merge_branches #{leftover.map { |n| ":#{n}" }.join(", ")}` " \
+            "or open with `branch(..., automerge: true)`."
         end
 
         # Marks a workflow as failed due to an unrecoverable error.

--- a/lib/chrono_forge/workflow.rb
+++ b/lib/chrono_forge/workflow.rb
@@ -28,6 +28,9 @@ module ChronoForge
     has_many :execution_logs, dependent: :destroy
     has_many :error_logs, dependent: :destroy
 
+    belongs_to :parent_execution_log,
+      class_name: "ChronoForge::ExecutionLog", optional: true
+
     enum :state, %i[
       idle
       running

--- a/lib/chrono_forge/workflow.rb
+++ b/lib/chrono_forge/workflow.rb
@@ -20,7 +20,10 @@
 #
 # Indexes
 #
-#  index_chrono_forge_workflows_on_key  (key) UNIQUE
+#  index_chrono_forge_workflows_on_key                         (key)
+#  index_chrono_forge_workflows_on_job_class_and_key           (job_class,key) UNIQUE
+#  index_chrono_forge_workflows_on_parent_execution_log_and_st (parent_execution_log_id,state)
+#  index_chrono_forge_workflows_on_state_and_completed_at      (state,completed_at)
 #
 module ChronoForge
   class Workflow < ApplicationRecord()

--- a/lib/chrono_forge/workflow.rb
+++ b/lib/chrono_forge/workflow.rb
@@ -12,6 +12,7 @@
 #  kwargs       :json             not null
 #  options      :json             not null
 #  locked_at    :datetime
+#  parent_execution_log_id :integer
 #  started_at   :datetime
 #  state        :integer          default("idle"), not null
 #  created_at   :datetime         not null
@@ -29,7 +30,9 @@ module ChronoForge
     has_many :error_logs, dependent: :destroy
 
     belongs_to :parent_execution_log,
-      class_name: "ChronoForge::ExecutionLog", optional: true
+      class_name: "ChronoForge::ExecutionLog",
+      inverse_of: :spawned_workflows,
+      optional: true
 
     enum :state, %i[
       idle

--- a/lib/generators/chrono_forge/migration_actions.rb
+++ b/lib/generators/chrono_forge/migration_actions.rb
@@ -18,6 +18,7 @@ module ChronoForge
         install_chrono_forge
         add_chrono_forge_workflow_state_index
         add_chrono_forge_error_log_step_context
+        add_chrono_forge_parent_execution_log
       ].freeze
 
       def copy_chrono_forge_migrations

--- a/lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb
+++ b/lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Adds chrono_forge_workflows.parent_execution_log_id: the execution log that
+# spawned a workflow (for branches, the branch$<name> log). Deliberately generic
+# so any future step that spawns sub-workflows can reuse it. The composite
+# [parent_execution_log_id, state] index makes the merge completion probe and the
+# dropped-job re-kick index-only at hundreds of thousands of children.
+#
+# Shipped standalone (matching add_chrono_forge_workflow_state_index) so existing
+# installs pick it up via `rails generate chrono_forge:upgrade`.
+class AddChronoForgeParentExecutionLog < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+
+  def change
+    add_column :chrono_forge_workflows, :parent_execution_log_id, parent_log_fk_type,
+      null: true, if_not_exists: true
+
+    add_index :chrono_forge_workflows, %i[parent_execution_log_id state],
+      if_not_exists: true, **chrono_forge_index_algorithm
+  end
+
+  private
+
+  # Match the type of chrono_forge_workflows.id so the FK lines up on both bigint
+  # and uuid installs.
+  def parent_log_fk_type
+    id_col = connection.columns(:chrono_forge_workflows).find { |c| c.name == "id" }
+    id_col && id_col.sql_type.to_s.downcase.include?("uuid") ? :uuid : :bigint
+  end
+
+  def chrono_forge_index_algorithm
+    if connection.adapter_name.to_s.downcase.include?("postgresql")
+      {algorithm: :concurrently}
+    else
+      {}
+    end
+  end
+end

--- a/lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb
+++ b/lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb
@@ -25,7 +25,7 @@ class AddChronoForgeParentExecutionLog < ActiveRecord::Migration[7.1]
   # and uuid installs.
   def parent_log_fk_type
     id_col = connection.columns(:chrono_forge_workflows).find { |c| c.name == "id" }
-    id_col && id_col.sql_type.to_s.downcase.include?("uuid") ? :uuid : :bigint
+    id_col&.type == :uuid ? :uuid : :bigint
   end
 
   def chrono_forge_index_algorithm

--- a/lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb
+++ b/lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb
@@ -25,7 +25,7 @@ class AddChronoForgeParentExecutionLog < ActiveRecord::Migration[7.1]
   # and uuid installs.
   def parent_log_fk_type
     id_col = connection.columns(:chrono_forge_workflows).find { |c| c.name == "id" }
-    id_col&.type == :uuid ? :uuid : :bigint
+    (id_col&.type == :uuid) ? :uuid : :bigint
   end
 
   def chrono_forge_index_algorithm

--- a/test/automerge_test.rb
+++ b/test/automerge_test.rb
@@ -28,7 +28,11 @@ class AutomergeTest < ActiveJob::TestCase
   def test_unmerged_branch_raises
     UnmergedBranchWorkflow.perform_later("um-1")
     error = assert_raises(ChronoForge::Executor::UnmergedBranchError) { perform_all_jobs }
-    assert_match(/forgotten/, error.message)
+    # Assert the contract (an opened-but-unjoined branch is reported with a fix
+    # hint), not just that the branch name is echoed.
+    assert_match(/never merged/, error.message)
+    assert_match(/automerge: true/, error.message)
+    assert_match(/forgotten/, error.message, "should name the offending branch")
   end
 
   # The inline automerge halts inside `branch` until the branch is joined, so a

--- a/test/automerge_test.rb
+++ b/test/automerge_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class AutomergeTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    ChronoForge::Workflow.destroy_all
+  end
+
+  # SingleSpawnWorkflow opens branch :grp with automerge: true and no explicit
+  # merge call. automerge must join inline at the branch block's close, which
+  # leaves a completed merge$grp log on the parent.
+  def test_automerge_joins_inline_at_block_close
+    SingleSpawnWorkflow.perform_later("am-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "am-1")
+    assert parent.completed?, "automerge branch should be joined before completion"
+
+    child = ChronoForge::Workflow.find_by(key: "am-1$grp$child")
+    assert child.completed?
+
+    merge_log = parent.execution_logs.find_by(step_name: "merge$grp")
+    assert merge_log, "automerge must go through the inline merge_branches path (merge$grp log)"
+    assert merge_log.completed?, "inline merge$grp log should be completed"
+  end
+
+  def test_unmerged_branch_raises
+    UnmergedBranchWorkflow.perform_later("um-1")
+    error = assert_raises(ChronoForge::Executor::UnmergedBranchError) { perform_all_jobs }
+    assert_match(/forgotten/, error.message)
+  end
+
+  # The inline automerge halts inside `branch` until the branch is joined, so a
+  # step that follows the branch must not run until the children are done.
+  def test_automerge_blocks_subsequent_steps
+    AutomergeThenStepWorkflow.perform_later("am-2")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "am-2")
+    assert parent.completed?, "workflow should complete once the branch joins and :after runs"
+
+    child = ChronoForge::Workflow.find_by(key: "am-2$grp$child")
+    assert child.completed?, "spawned child should be completed"
+
+    assert_equal true, parent.context["after"], ":after step should have run"
+
+    merge_log = parent.execution_logs.find_by(step_name: "merge$grp")
+    after_log = parent.execution_logs.find_by(step_name: "durably_execute$after")
+    assert merge_log&.completed?, "inline merge$grp log should be completed"
+    assert after_log&.completed?, ":after step log should be completed"
+    assert_operator after_log.id, :>, merge_log.id,
+      ":after must not run until the automerge branch is joined"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+class AutomergeThenStepWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :grp, automerge: true do
+      spawn :child, NoopChild
+    end
+    durably_execute :after
+  end
+
+  private
+
+  def after
+    context["after"] = true
+  end
+end

--- a/test/branch_associations_test.rb
+++ b/test/branch_associations_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class BranchAssociationsTest < ActiveJob::TestCase
+  def test_parent_execution_log_and_spawned_workflows_round_trip
+    parent = ChronoForge::Workflow.create!(key: "p-#{SecureRandom.hex}", job_class: "X")
+    log = parent.execution_logs.create!(step_name: "branch$grp")
+    child = ChronoForge::Workflow.create!(
+      key: "c-#{SecureRandom.hex}", job_class: "Y", parent_execution_log_id: log.id
+    )
+
+    assert_equal log, child.parent_execution_log
+    assert_includes log.spawned_workflows, child
+  end
+end

--- a/test/branch_integration_test.rb
+++ b/test/branch_integration_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class BranchIntegrationTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    ChronoForge::Workflow.destroy_all
+    User.delete_all
+  end
+
+  # -------------------------------------------------------------------------
+  # Test 1: Empty spawn_each source
+  #
+  # When User.all is empty the branch block runs but spawn_each dispatches
+  # nothing.  The branch must still seal and automerge inline so the parent
+  # can complete.
+  # -------------------------------------------------------------------------
+  def test_empty_spawn_each_source_seals_and_completes
+    SpawnEachWorkflow.perform_later("empty-src-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "empty-src-1")
+    assert parent.completed?, "parent should complete when source is empty"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    assert branch_log, "branch$grp execution log must exist"
+    assert branch_log.completed?, "branch$grp log must be sealed (completed)"
+
+    child_count = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).count
+    assert_equal 0, child_count, "no children should have been spawned for an empty source"
+  end
+
+  # -------------------------------------------------------------------------
+  # Test 2: Empty branch body (no spawns)
+  #
+  # A branch block that contains no spawn calls must still seal via automerge
+  # and allow execution to continue to the next step.
+  # -------------------------------------------------------------------------
+  def test_empty_branch_body_resolves_immediately_and_continues
+    job_klass = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+
+      def perform
+        branch :empty, automerge: true do
+          # no spawns
+        end
+        durably_execute :after
+      end
+
+      private
+
+      def after
+        context["after"] = true
+      end
+    end
+    Object.const_set(:EmptyBranchWorkflow, job_klass)
+
+    EmptyBranchWorkflow.perform_later("empty-branch-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "empty-branch-1")
+    assert parent.completed?, "parent should complete after empty automerge branch"
+    assert_equal true, parent.context["after"],
+      ":after step must run once the empty branch resolves"
+  ensure
+    Object.send(:remove_const, :EmptyBranchWorkflow) if defined?(EmptyBranchWorkflow)
+  end
+
+  # -------------------------------------------------------------------------
+  # Test 3: Nested branches (child workflow opens its own branch)
+  #
+  # NestingParentWorkflow
+  #   branch :top, automerge: true
+  #     spawn :c, NestingChild          → key: "nest-1$top$c"
+  #
+  # NestingChild
+  #   branch :sub, automerge: true
+  #     spawn :gc, NoopChild            → key: "nest-1$top$c$sub$gc"
+  #
+  # The multi-level automerge poll cascade must drain fully so the whole
+  # tree reaches :completed bottom-up.
+  # -------------------------------------------------------------------------
+  def test_nested_branches_complete_bottom_up
+    NestingParentWorkflow.perform_later("nest-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "nest-1")
+    assert parent.completed?, "top-level parent should complete"
+
+    child = ChronoForge::Workflow.find_by(key: "nest-1$top$c")
+    assert child, "NestingChild workflow row must exist"
+    assert child.completed?, "NestingChild should complete"
+
+    grandchild = ChronoForge::Workflow.find_by(key: "nest-1$top$c$sub$gc")
+    assert grandchild, "NoopChild (grandchild) workflow row must exist"
+    assert grandchild.completed?, "NoopChild grandchild should complete"
+  end
+end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -47,4 +47,13 @@ class BranchMergeJobTest < ActiveJob::TestCase
       ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
     end
   end
+
+  def test_does_not_rekick_running_child
+    running = child!(state: :running, started_at: nil)
+    running.update_column(:updated_at, 10.minutes.ago)
+    assert_enqueued_with(job: ChronoForge::BranchMergeJob) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+    assert_no_enqueued_jobs(only: NoopChild)
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class BranchMergeJobTest < ActiveJob::TestCase
+  def setup
+    ChronoForge::Workflow.where(key: "bmj-parent").destroy_all
+    @parent = ChronoForge::Workflow.create!(key: "bmj-parent", job_class: "SingleSpawnWorkflow")
+    @log = @parent.execution_logs.create!(step_name: "branch$g", state: :completed)
+  end
+
+  def child!(state:, started_at: Time.current)
+    ChronoForge::Workflow.create!(
+      key: "c-#{SecureRandom.hex}", job_class: "NoopChild",
+      parent_execution_log_id: @log.id, state: state, started_at: started_at
+    )
+  end
+
+  def test_wakes_parent_when_all_complete
+    child!(state: :completed)
+    assert_enqueued_with(job: SingleSpawnWorkflow, args: ["bmj-parent"]) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+
+  def test_reschedules_when_incomplete
+    child!(state: :running)
+    assert_enqueued_with(job: ChronoForge::BranchMergeJob) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+    assert_no_enqueued_jobs(only: SingleSpawnWorkflow)
+  end
+
+  def test_does_not_wake_when_branch_not_sealed
+    unsealed = @parent.execution_logs.create!(step_name: "branch$h", state: :pending)
+    # children all complete, but branch not sealed yet
+    ChronoForge::Workflow.create!(key: "c-x", job_class: "NoopChild",
+      parent_execution_log_id: unsealed.id, state: :completed, started_at: Time.current)
+    assert_enqueued_with(job: ChronoForge::BranchMergeJob) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [unsealed.id], 5, 300)
+    end
+    assert_no_enqueued_jobs(only: SingleSpawnWorkflow)
+  end
+
+  def test_rekicks_never_started_child
+    stuck = child!(state: :idle, started_at: nil)
+    stuck.update_column(:updated_at, 10.minutes.ago)
+    assert_enqueued_with(job: NoopChild, args: [stuck.key]) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -73,4 +73,65 @@ class BranchMergeJobTest < ActiveJob::TestCase
       ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [], 5, 300)
     end
   end
+
+  # A freshly-dispatched idle child has NOT exceeded REKICK_AFTER yet, so it
+  # must not be re-enqueued — only children stale past the threshold are
+  # presumed dropped.
+  def test_does_not_rekick_recent_idle_child
+    recent = child!(state: :idle, started_at: nil)
+    recent.update_column(:updated_at, 1.minute.ago)
+    assert_no_enqueued_jobs(only: NoopChild) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+
+  # Failed/stalled children need operator recovery — a blind rekick must never
+  # touch them. Both are "incomplete" so pending > 0 and the poller does NOT
+  # early-return; it must still skip them when selecting idle candidates.
+  def test_does_not_rekick_failed_or_stalled_children
+    failed = child!(state: :failed, started_at: nil)
+    stalled = child!(state: :stalled, started_at: nil)
+    failed.update_column(:updated_at, 10.minutes.ago)
+    stalled.update_column(:updated_at, 10.minutes.ago)
+    assert_no_enqueued_jobs(only: NoopChild) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+
+  # When more stale-idle children exist than REKICK_BATCH, exactly REKICK_BATCH
+  # are re-enqueued in one poll; the rest are handled on the next pass.
+  def test_rekick_is_capped_at_batch_size
+    stale = 10.minutes.ago
+    rows = (ChronoForge::BranchMergeJob::REKICK_BATCH + 5).times.map do
+      {
+        key: "cap-#{SecureRandom.hex}",
+        job_class: "NoopChild",
+        parent_execution_log_id: @log.id,
+        state: ChronoForge::Workflow.states[:idle],
+        kwargs: {},
+        options: {},
+        context: {},
+        created_at: stale,
+        updated_at: stale
+      }
+    end
+    ChronoForge::Workflow.insert_all(rows)
+
+    assert_enqueued_jobs(ChronoForge::BranchMergeJob::REKICK_BATCH, only: NoopChild) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+
+  # A rekicked child doesn't just get enqueued — it runs to :completed,
+  # closing the full recovery loop.
+  def test_rekicked_child_runs_to_completion
+    stuck = child!(state: :idle, started_at: nil)
+    stuck.update_column(:updated_at, 10.minutes.ago)
+
+    ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+
+    perform_enqueued_jobs(only: NoopChild)
+
+    assert stuck.reload.completed?, "rekicked child must run to completion"
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -65,4 +65,12 @@ class BranchMergeJobTest < ActiveJob::TestCase
     assert ChronoForge::BranchMergeJob.rescue_handlers.any? { |klass, _| klass == "StandardError" },
       "BranchMergeJob must declare retry_on StandardError so transient errors do not orphan the parent"
   end
+
+  # The empty-input guard is a caller bug, not a transient fault: discard_on
+  # ArgumentError makes it fail fast rather than retrying 25× via retry_on.
+  def test_empty_branch_log_ids_is_discarded_not_retried
+    assert_no_enqueued_jobs do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [], 5, 300)
+    end
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -57,19 +57,19 @@ class BranchMergeJobTest < ActiveJob::TestCase
     assert_no_enqueued_jobs(only: NoopChild)
   end
 
-  # Fix 1: retry_on prevents a transient error from orphaning the parent in :idle.
-  # We use the structural assertion (rescue_handlers) rather than fighting test-adapter
-  # retry mechanics: the important invariant is that the declaration is in place so
-  # a real backend re-enqueues the job on failure.
+  # Fix 1: the poller retries TRANSIENT infrastructure errors so a DB blip does not
+  # orphan the parent in :idle. Structural assertion (rescue_handlers) rather than
+  # fighting test-adapter retry mechanics: the invariant is that the declaration is
+  # in place so a real backend re-enqueues the job on a transient error.
   def test_poller_retries_on_transient_error
-    assert ChronoForge::BranchMergeJob.rescue_handlers.any? { |klass, _| klass == "StandardError" },
-      "BranchMergeJob must declare retry_on StandardError so transient errors do not orphan the parent"
+    assert ChronoForge::BranchMergeJob.rescue_handlers.any? { |klass, _| klass == "ActiveRecord::Deadlocked" },
+      "BranchMergeJob must retry transient DB errors so they do not orphan the parent"
   end
 
-  # The empty-input guard is a caller bug, not a transient fault: discard_on
-  # ArgumentError makes it fail fast rather than retrying 25× via retry_on.
-  def test_empty_branch_log_ids_is_discarded_not_retried
-    assert_no_enqueued_jobs do
+  # A programming bug (e.g. the empty-input guard) must propagate loudly to the
+  # backend's failed-job queue, NOT be silently retried-then-discarded.
+  def test_empty_branch_log_ids_propagates_loudly
+    assert_raises(ArgumentError) do
       ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [], 5, 300)
     end
   end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -148,4 +148,52 @@ class BranchMergeJobTest < ActiveJob::TestCase
 
     assert stuck.reload.completed?, "rekicked child must run to completion"
   end
+
+  # Each poll stamps its observable state onto the target branch log's metadata so
+  # a dashboard can surface in-flight merges (ActiveJob can't be queried for the
+  # scheduled poller). While work remains, next_poll_at is set.
+  def test_records_poll_state_on_branch_log
+    child!(state: :running)
+    ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+
+    poll = @log.reload.metadata["poll"]
+    assert poll, "poll state should be recorded on the branch log"
+    assert_equal 1, poll["pending"]
+    assert_equal true, poll["sealed"]
+    assert poll["last_polled_at"], "last_polled_at should be recorded"
+    assert poll["next_poll_at"], "next_poll_at should be set while still polling"
+    assert_equal 1, poll["polls"]
+  end
+
+  # The poll state must not clobber spawn_each's cursors — both live in the same
+  # branch-log metadata under separate keys.
+  def test_poll_state_preserves_existing_branch_metadata
+    @log.update!(metadata: {"cursors" => {"items" => {"pk" => 42}}})
+    child!(state: :running)
+    ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+
+    meta = @log.reload.metadata
+    assert_equal 42, meta.dig("cursors", "items", "pk"), "spawn_each cursors must be preserved"
+    assert meta["poll"], "poll state should be added alongside cursors"
+  end
+
+  # On the wake (done) poll, pending is 0 and there is no next poll scheduled.
+  def test_records_final_poll_with_no_next_when_complete
+    child!(state: :completed)
+    ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+
+    poll = @log.reload.metadata["poll"]
+    assert_equal 0, poll["pending"]
+    assert_equal true, poll["sealed"]
+    assert_nil poll["next_poll_at"], "no next poll once the merge is done"
+  end
+
+  # The poll counter accumulates across successive polls.
+  def test_poll_count_increments_across_polls
+    child!(state: :running)
+    2.times do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+    assert_equal 2, @log.reload.metadata["poll"]["polls"]
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -227,4 +227,18 @@ class BranchMergeJobTest < ActiveJob::TestCase
     assert_equal "new", meta["poll_token"], "stale poller must not rotate the token"
     assert_nil meta["poll"], "stale poller must not write poll state"
   end
+
+  # Adaptive cadence: the reschedule delay scales with pending and clamps to
+  # [min_interval, max_interval].
+  def test_reschedule_delay_scales_and_clamps
+    job = ChronoForge::BranchMergeJob.new
+    factor = ChronoForge::BranchMergeJob::FACTOR
+
+    # Few pending → clamps up to min_interval.
+    assert_equal 5, job.send(:reschedule_delay, 1, 5, 300)
+    # Mid-range → scales linearly by FACTOR (100 * 0.06 = 6).
+    assert_in_delta 100 * factor, job.send(:reschedule_delay, 100, 5, 300), 0.001
+    # Huge pending → clamps down to max_interval.
+    assert_equal 300, job.send(:reschedule_delay, 1_000_000, 5, 300)
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -196,4 +196,35 @@ class BranchMergeJobTest < ActiveJob::TestCase
     end
     assert_equal 2, @log.reload.metadata["poll"]["polls"]
   end
+
+  # Fencing: a poller whose token no longer matches the branch log's stored token
+  # has been superseded by a newer merge_branches pass. It must stop dead — no
+  # reschedule, no parent wake, no rekick — even though there is pending work.
+  def test_superseded_poller_with_stale_token_stops
+    @log.update!(metadata: {"poll_token" => "current"})
+    child!(state: :running) # would otherwise force a reschedule
+    assert_no_enqueued_jobs do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300, "stale")
+    end
+  end
+
+  # The current-token poller is the live chain and keeps polling.
+  def test_current_token_poller_proceeds
+    @log.update!(metadata: {"poll_token" => "tok"})
+    child!(state: :running)
+    assert_enqueued_with(job: ChronoForge::BranchMergeJob) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300, "tok")
+    end
+  end
+
+  # A superseded poller must never clobber the newer chain's token or write poll
+  # state — the stored token stays put and no "poll" key is written.
+  def test_superseded_poller_does_not_touch_metadata
+    @log.update!(metadata: {"poll_token" => "new"})
+    child!(state: :running)
+    ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300, "old")
+    meta = @log.reload.metadata
+    assert_equal "new", meta["poll_token"], "stale poller must not rotate the token"
+    assert_nil meta["poll"], "stale poller must not write poll state"
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -56,4 +56,13 @@ class BranchMergeJobTest < ActiveJob::TestCase
     end
     assert_no_enqueued_jobs(only: NoopChild)
   end
+
+  # Fix 1: retry_on prevents a transient error from orphaning the parent in :idle.
+  # We use the structural assertion (rescue_handlers) rather than fighting test-adapter
+  # retry mechanics: the important invariant is that the declaration is in place so
+  # a real backend re-enqueues the job on failure.
+  def test_poller_retries_on_transient_error
+    assert ChronoForge::BranchMergeJob.rescue_handlers.any? { |klass, _| klass == "StandardError" },
+      "BranchMergeJob must declare retry_on StandardError so transient errors do not orphan the parent"
+  end
 end

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -98,6 +98,20 @@ class BranchMergeJobTest < ActiveJob::TestCase
     end
   end
 
+  # A child that ran and is now parked on a wait/wait_until is :idle with
+  # started_at SET — it has been picked up, just halted waiting. It must NOT be
+  # mistaken for a dropped (never-run) child and rekicked: that would re-check the
+  # wait condition prematurely and pile up duplicate scheduled jobs. The updated_at
+  # here is deliberately stale (10 min) to prove started_at — not staleness — is
+  # what spares it.
+  def test_does_not_rekick_waiting_child
+    waiting = child!(state: :idle, started_at: 20.minutes.ago)
+    waiting.update_column(:updated_at, 10.minutes.ago)
+    assert_no_enqueued_jobs(only: NoopChild) do
+      ChronoForge::BranchMergeJob.perform_now("bmj-parent", "SingleSpawnWorkflow", [@log.id], 5, 300)
+    end
+  end
+
   # When more stale-idle children exist than REKICK_BATCH, exactly REKICK_BATCH
   # are re-enqueued in one poll; the rest are handled on the next pass.
   def test_rekick_is_capped_at_batch_size

--- a/test/branch_recovery_test.rb
+++ b/test/branch_recovery_test.rb
@@ -242,4 +242,23 @@ class BranchRecoveryTest < ActiveJob::TestCase
       ChronoForge::Workflow.states[:stalled]
     ]).count, "no failed/stalled children"
   end
+
+  # setup_workflow! stamps started_at the first time a pre-inserted child runs.
+  # Branch children are inserted by the parent (insert_all) without started_at;
+  # this stamp is what lets the rekick poller tell "ran, now waiting" (started_at
+  # set) from "never picked up / dropped" (started_at nil).
+  def test_pre_inserted_child_records_started_at_on_first_run
+    row = ChronoForge::Workflow.create!(
+      key: "started-at-1", job_class: "NoopChild",
+      kwargs: {}, options: {}, context: {}, state: :idle, started_at: nil
+    )
+    assert_nil row.started_at
+
+    NoopChild.perform_later("started-at-1")
+    perform_all_jobs
+
+    row.reload
+    assert row.completed?, "child should complete"
+    assert_not_nil row.started_at, "started_at must be stamped on first execution"
+  end
 end

--- a/test/branch_recovery_test.rb
+++ b/test/branch_recovery_test.rb
@@ -52,6 +52,149 @@ class BranchRecoveryTest < ActiveJob::TestCase
     assert_equal 0, bad, "no child should be failed/stalled from a spurious re-run"
   end
 
+  # AR path, mid-stream: glitch fires AFTER the first batch's advance_cursor! so the
+  # cursor is persisted with start: <users[of-1].id>. On resume, spawn_each picks up
+  # from that non-nil PK — it does NOT restart from scratch. The boundary record is
+  # re-yielded (inclusive keyset) but insert_all dedups its identical key, so we
+  # still end up with exactly 25 distinct children and zero failed/stalled.
+  def test_ar_path_resumes_mid_stream_from_nonnil_cursor
+    branch_rb = ChronoForge::Executor::Methods::Branch
+      .instance_method(:spawn_each).source_location[0]
+
+    ar_cursor_line = File.readlines(branch_rb)
+      .each_with_index
+      .find { |line, _| line.include?("advance_cursor!") && line.include?("pk:") }
+      .then { |_line, idx| idx + 1 }
+
+    run_scenario(
+      SpawnEachWorkflow.new("ar-mid", of: 10),
+      glitch: ["after", "#{branch_rb}:#{ar_cursor_line}"]
+    )
+
+    parent = ChronoForge::Workflow.find_by(key: "ar-mid")
+    assert parent.completed?, "workflow should complete after mid-stream AR cursor resume"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+
+    assert_equal 25, children.count, "exactly 25 children after mid-stream AR resume (no extras)"
+    assert_equal 25, children.distinct.count(:key), "no duplicate child keys"
+
+    bad = children.where(state: [
+      ChronoForge::Workflow.states[:failed],
+      ChronoForge::Workflow.states[:stalled]
+    ]).count
+    assert_equal 0, bad, "no child should be failed/stalled after mid-stream AR resume"
+  end
+
+  # Enumerable path, mid-stream: glitch fires AFTER the first batch's advance_cursor!
+  # (n: n line). The cursor is persisted at n=of, so resume calls source.drop(n) and
+  # skips the already-dispatched items — no overlap, no gap, no dupes.
+  def test_enumerable_path_resumes_mid_stream
+    branch_rb = ChronoForge::Executor::Methods::Branch
+      .instance_method(:spawn_each).source_location[0]
+
+    enum_cursor_line = File.readlines(branch_rb)
+      .each_with_index
+      .find { |line, _| line.include?("advance_cursor!") && line.include?("n: n") }
+      .then { |_line, idx| idx + 1 }
+
+    items = (1..25).to_a
+    run_scenario(
+      EnumSpawnWorkflow.new("enum-mid", items: items, of: 10),
+      glitch: ["after", "#{branch_rb}:#{enum_cursor_line}"]
+    )
+
+    parent = ChronoForge::Workflow.find_by(key: "enum-mid")
+    assert parent.completed?, "workflow should complete after mid-stream enumerable resume"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+
+    assert_equal 25, children.count, "exactly 25 children after mid-stream enum resume (no extras)"
+    assert_equal 25, children.distinct.count(:key), "no duplicate child keys"
+
+    bad = children.where(state: [
+      ChronoForge::Workflow.states[:failed],
+      ChronoForge::Workflow.states[:stalled]
+    ]).count
+    assert_equal 0, bad, "no child should be failed/stalled after mid-stream enum resume"
+  end
+
+  # Enumerable path, from-scratch: glitch fires BEFORE the first advance_cursor! in
+  # the enum branch — n is never persisted. On resume drop(0) re-yields the whole
+  # stream, producing identical things_{n} keys; insert_all dedups them so no
+  # duplicates exist and all 25 children complete cleanly.
+  def test_enumerable_path_resumes_from_scratch_dedups
+    branch_rb = ChronoForge::Executor::Methods::Branch
+      .instance_method(:spawn_each).source_location[0]
+
+    enum_cursor_line = File.readlines(branch_rb)
+      .each_with_index
+      .find { |line, _| line.include?("advance_cursor!") && line.include?("n: n") }
+      .then { |_line, idx| idx + 1 }
+
+    items = (1..25).to_a
+    run_scenario(
+      EnumSpawnWorkflow.new("enum-scratch", items: items, of: 10),
+      glitch: ["before", "#{branch_rb}:#{enum_cursor_line}"]
+    )
+
+    parent = ChronoForge::Workflow.find_by(key: "enum-scratch")
+    assert parent.completed?, "workflow should complete after from-scratch enum resume"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+
+    assert_equal 25, children.count, "exactly 25 children after from-scratch enum resume (no dupes)"
+    assert_equal 25, children.distinct.count(:key), "no duplicate child keys"
+
+    bad = children.where(state: [
+      ChronoForge::Workflow.states[:failed],
+      ChronoForge::Workflow.states[:stalled]
+    ]).count
+    assert_equal 0, bad, "no child should be failed/stalled after from-scratch enum resume"
+  end
+
+  # Finest-grained gap: crash AFTER insert_all commits child rows (:idle) but BEFORE
+  # perform_all_later enqueues them. On resume the branch re-dispatches: insert_all
+  # ignores the existing idle rows; the idle-filter finds them still :idle and
+  # enqueues them. Every child inserted-but-never-enqueued still runs to :completed.
+  def test_resumes_when_crash_between_insert_and_enqueue
+    branch_rb = ChronoForge::Executor::Methods::Branch
+      .instance_method(:spawn_each).source_location[0]
+
+    perform_all_later_line = File.readlines(branch_rb)
+      .each_with_index
+      .find { |line, _| line.include?("ActiveJob.perform_all_later") }
+      .then { |_line, idx| idx + 1 }
+
+    run_scenario(
+      SpawnEachWorkflow.new("gap-1", of: 10),
+      glitch: ["before", "#{branch_rb}:#{perform_all_later_line}"]
+    )
+
+    parent = ChronoForge::Workflow.find_by(key: "gap-1")
+    assert parent.completed?, "workflow should complete after insert/enqueue gap resume"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+
+    assert_equal 25, children.count, "exactly 25 children after insert/enqueue gap resume"
+    assert_equal 25, children.distinct.count(:key), "no duplicate child keys"
+
+    bad = children.where(state: [
+      ChronoForge::Workflow.states[:failed],
+      ChronoForge::Workflow.states[:stalled]
+    ]).count
+    assert_equal 0, bad, "no child should be failed/stalled after insert/enqueue gap"
+
+    # Key property: children inserted but never enqueued (still :idle at crash time)
+    # must be picked up and run to :completed on resume — none should be stuck :idle.
+    stuck_idle = children.where(state: ChronoForge::Workflow.states[:idle]).count
+    assert_equal 0, stuck_idle, "no child should remain :idle — all must be run after insert/enqueue gap"
+  end
+
   # Focused unit test of the dispatch filter: a child already :completed must NOT
   # be re-enqueued when its chunk is re-dispatched on resume. We pre-seed a
   # completed child whose key the re-yielded stream will produce, then re-run

--- a/test/branch_recovery_test.rb
+++ b/test/branch_recovery_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class BranchRecoveryTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    User.delete_all
+    @users = 25.times.map { |i| User.create!(name: "u#{i}", email: "u#{i}@e.com") }
+  end
+
+  # Prove cursor-resume + boundary-dedup with a real ChaoticJob glitch.
+  #
+  # The glitch fires once "before" advance_cursor! in the AR path — i.e. after
+  # dispatch_children commits the first batch (insert_all + perform_all_later) but
+  # before the cursor is persisted. ChaoticJob retries the parent job, which must
+  # RESUME spawn_each from start: nil (the cursor never advanced), re-yielding the
+  # whole stream. Because AR children are keyed by record.id ("key$grp$items_<id>"),
+  # the re-yielded boundary records collapse to identical keys — insert_all dedups
+  # them. And the queue-idempotency fix means already-run children are NOT
+  # re-enqueued, so none end up failed/stalled.
+  def test_resumes_dispatch_from_cursor_with_no_duplicate_children
+    branch_rb = ChronoForge::Executor::Methods::Branch
+      .instance_method(:spawn_each).source_location[0]
+
+    # 1-based line of the AR-path advance_cursor! call (inside find_in_batches).
+    advance_line = File.readlines(branch_rb)
+      .each_with_index
+      .find { |line, _| line.include?("advance_cursor!") && line.include?("pk:") }
+      .then { |_line, idx| idx + 1 }
+
+    run_scenario(
+      SpawnEachWorkflow.new("rec-1", of: 10),
+      glitch: ["before", "#{branch_rb}:#{advance_line}"]
+    )
+
+    parent = ChronoForge::Workflow.find_by(key: "rec-1")
+    assert parent.completed?, "workflow should complete after cursor-resume"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+
+    assert_equal 25, children.count, "exactly N children after cursor-resume (no extras)"
+    assert_equal 25, children.distinct.count(:key), "no duplicate child keys"
+
+    # The queue-idempotency guarantee: a child dispatched before the glitch must
+    # not be re-enqueued+re-run on resume. A spurious re-run of a completed child
+    # raises NotExecutableError → stalled/failed. Zero such children proves the fix.
+    bad = children.where(state: [
+      ChronoForge::Workflow.states[:failed],
+      ChronoForge::Workflow.states[:stalled]
+    ]).count
+    assert_equal 0, bad, "no child should be failed/stalled from a spurious re-run"
+  end
+
+  # Focused unit test of the dispatch filter: a child already :completed must NOT
+  # be re-enqueued when its chunk is re-dispatched on resume. We pre-seed a
+  # completed child whose key the re-yielded stream will produce, then re-run
+  # spawn_each from a cursor that re-yields it (start at its PK). The completed
+  # child's row stays completed and no fresh NoopChild job is enqueued for its key.
+  def test_dispatch_does_not_reenqueue_completed_children
+    # Build a partially-dispatched branch: parent idle, branch pending, and the
+    # first user's child already COMPLETED (as if it ran before a crash).
+    parent = ChronoForge::Workflow.create!(
+      key: "rec-2", job_class: "SpawnEachWorkflow",
+      kwargs: {"of" => 10}, options: {}, context: {}, state: :idle
+    )
+    branch_log = parent.execution_logs.create!(
+      step_name: "branch$grp", state: :pending, started_at: Time.current, metadata: {}
+    )
+
+    first_user = @users.first
+    completed_key = "rec-2$grp$items_#{first_user.id}"
+    completed_child = ChronoForge::Workflow.create!(
+      key: completed_key, job_class: "NoopChild",
+      kwargs: {user_id: first_user.id}, options: {}, context: {},
+      state: :completed, parent_execution_log_id: branch_log.id
+    )
+
+    # Re-run. spawn_each replays from start: nil, re-yielding first_user first.
+    # dispatch_children's insert_all ignores the existing completed row, and the
+    # idle-filter skips enqueuing it; only the genuinely-new (idle) children run.
+    SpawnEachWorkflow.perform_later("rec-2", of: 10)
+    perform_all_jobs
+
+    # The completed child must not have been re-run (no NotExecutableError, state
+    # unchanged) — and exactly one row exists for its key (no duplicate insert).
+    completed_child.reload
+    assert completed_child.completed?, "pre-completed child must stay completed (not re-run)"
+    assert_equal 1, ChronoForge::Workflow.where(key: completed_key).count,
+      "no duplicate row for the completed child's key"
+
+    # The whole fan-out still finishes: 25 distinct children, parent completed.
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+    assert_equal 25, children.count, "all 25 children present after resume"
+    assert_equal 25, children.distinct.count(:key), "no duplicate child keys"
+    assert parent.reload.completed?, "workflow should complete"
+    assert_equal 0, children.where(state: [
+      ChronoForge::Workflow.states[:failed],
+      ChronoForge::Workflow.states[:stalled]
+    ]).count, "no failed/stalled children"
+  end
+end

--- a/test/branch_replay_test.rb
+++ b/test/branch_replay_test.rb
@@ -1,0 +1,197 @@
+require "test_helper"
+
+# Replay robustness + DB-impact tests for ChronoForge branch workflows.
+#
+# The executor replays the whole `perform` body on every resume. The key
+# correctness properties proved here:
+#
+#  1. A replay pass does NOT re-create or re-enqueue any children (idempotent
+#     dispatch — the sealed branch$<name> log guards the block).
+#  2. Replay SELECT cost on chrono_forge_workflows is O(1) w.r.t. child count —
+#     branches use an exists?-based probe, never a per-child scan.
+#  3. Repeated replays converge: no duplicate children, parent re-completes
+#     cleanly every time.
+#  4. No writes (INSERTs/UPDATEs) to chrono_forge_workflows scale with child
+#     count on replay — only the parent's own state transitions happen.
+class BranchReplayTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    ChronoForge::Workflow.destroy_all
+    User.delete_all
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 1: A replay pass does not re-dispatch any children
+  # ---------------------------------------------------------------------------
+  def test_replay_does_not_redispatch_children
+    5.times { |i| User.create!(name: "u#{i}", email: "u#{i}@example.com") }
+
+    ReplayBranchWorkflow.perform_later("replay-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "replay-1")
+    assert parent.completed?, "parent should be completed after initial run"
+
+    branch_log = parent.execution_logs.find_by(step_name: "branch$items")
+    children_before = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+    assert_equal 5, children_before.count, "should have 5 children after initial run"
+    assert children_before.all?(&:completed?), "all children should be completed"
+
+    child_keys_before = children_before.pluck(:key).to_set
+
+    inserts_during_replay = count_sql("INSERT", "chrono_forge_workflows") do
+      assert_no_enqueued_jobs(only: NoopChild) do
+        replay_pass!("replay-1")
+      end
+    end
+
+    assert_equal 0, inserts_during_replay,
+      "replay must not INSERT any new rows into chrono_forge_workflows (no new children), got #{inserts_during_replay}"
+
+    # Child count unchanged
+    children_after = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.reload.id)
+    assert_equal 5, children_after.count, "child count must not change on replay"
+
+    # Same keys
+    child_keys_after = children_after.pluck(:key).to_set
+    assert_equal child_keys_before, child_keys_after, "child keys must be identical after replay"
+
+    # All children still completed
+    assert children_after.all?(&:completed?), "all children must remain completed after replay"
+
+    # Parent completed again
+    assert ChronoForge::Workflow.find_by(key: "replay-1").completed?,
+      "parent must be completed after replay"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 2: Replay SELECT cost on the workflows table is independent of child
+  # count — proves no per-child scan during the merge probe path.
+  # ---------------------------------------------------------------------------
+  def test_replay_select_cost_independent_of_child_count
+    # Run with 3 children
+    3.times { |i| User.create!(name: "few_#{i}", email: "few#{i}@example.com") }
+    ReplayBranchWorkflow.perform_later("replay-few")
+    perform_all_jobs
+    assert ChronoForge::Workflow.find_by(key: "replay-few").completed?, "few-child workflow must complete"
+
+    few = count_sql("SELECT", "chrono_forge_workflows") do
+      replay_pass!("replay-few", drop_merge_logs: true)
+    end
+
+    # Reset and run with 30 children
+    User.delete_all
+    ChronoForge::Workflow.where.not(key: "replay-few").destroy_all
+    30.times { |i| User.create!(name: "many_#{i}", email: "many#{i}@example.com") }
+    ReplayBranchWorkflow.perform_later("replay-many")
+    perform_all_jobs
+    assert ChronoForge::Workflow.find_by(key: "replay-many").completed?, "many-child workflow must complete"
+
+    many = count_sql("SELECT", "chrono_forge_workflows") do
+      replay_pass!("replay-many", drop_merge_logs: true)
+    end
+
+    puts "replay SELECTs on workflows: few=#{few} many=#{many}"
+
+    assert_equal few, many,
+      "replay SELECT cost on chrono_forge_workflows must be constant regardless of child count " \
+      "(got few=#{few} vs many=#{many}); a difference would indicate a per-child scan — a real replay bug"
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 3: Repeated replays stay idempotent
+  # ---------------------------------------------------------------------------
+  def test_repeated_replays_stay_idempotent
+    4.times { |i| User.create!(name: "loop_#{i}", email: "loop#{i}@example.com") }
+
+    ReplayBranchWorkflow.perform_later("replay-loop")
+    perform_all_jobs
+
+    assert ChronoForge::Workflow.find_by(key: "replay-loop").completed?,
+      "parent should be completed after initial run"
+
+    3.times do |pass|
+      assert_no_enqueued_jobs(only: NoopChild) do
+        replay_pass!("replay-loop")
+      end
+
+      parent = ChronoForge::Workflow.find_by(key: "replay-loop")
+      assert parent.completed?, "parent must be completed after replay pass #{pass + 1}"
+      assert_equal true, parent.context["finalized"],
+        "context[finalized] must be true after replay pass #{pass + 1}"
+
+      branch_log = parent.execution_logs.find_by(step_name: "branch$items")
+      children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+      assert_equal 4, children.count,
+        "child count must remain 4 after replay pass #{pass + 1}"
+      assert_equal 4, children.distinct.count(:key),
+        "no duplicate child keys after replay pass #{pass + 1}"
+      assert children.all?(&:completed?),
+        "all children must remain completed after replay pass #{pass + 1}"
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Test 4: Replay write impact is zero/bounded and does not scale with children
+  # ---------------------------------------------------------------------------
+  def test_replay_write_impact_is_zero_on_workflows_table
+    # Measure INSERTs and UPDATEs for 5 children to assert baseline
+    5.times { |i| User.create!(name: "write_#{i}", email: "write#{i}@example.com") }
+    ReplayBranchWorkflow.perform_later("replay-writes")
+    perform_all_jobs
+
+    inserts = count_sql("INSERT", "chrono_forge_workflows") { replay_pass!("replay-writes") }
+    updates_5 = count_sql("UPDATE", "chrono_forge_workflows") { replay_pass!("replay-writes") }
+
+    assert_equal 0, inserts, "replay must not INSERT any workflow rows (got #{inserts})"
+    puts "replay UPDATEs on workflows (5 children): #{updates_5}"
+
+    # Now measure UPDATEs with 30 children and assert the count does NOT scale
+    User.delete_all
+    ChronoForge::Workflow.where.not(key: "replay-writes").destroy_all
+    30.times { |i| User.create!(name: "write30_#{i}", email: "write30_#{i}@example.com") }
+    ReplayBranchWorkflow.perform_later("replay-writes-30")
+    perform_all_jobs
+
+    inserts_30 = count_sql("INSERT", "chrono_forge_workflows") { replay_pass!("replay-writes-30") }
+    updates_30 = count_sql("UPDATE", "chrono_forge_workflows") { replay_pass!("replay-writes-30") }
+
+    assert_equal 0, inserts_30, "replay must not INSERT any workflow rows for 30 children (got #{inserts_30})"
+    puts "replay UPDATEs on workflows (30 children): #{updates_30}"
+
+    assert_equal updates_5, updates_30,
+      "replay UPDATE count must not scale with child count " \
+      "(got #{updates_5} for 5 children vs #{updates_30} for 30 children); " \
+      "children must never be updated during a parent replay pass"
+  end
+
+  private
+
+  # Count SQL statements matching op (INSERT|SELECT|UPDATE|DELETE) against a table.
+  def count_sql(op, table)
+    pattern = /#{op}\b.*\b#{Regexp.escape(table)}\b/i
+    count = 0
+    sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*a|
+      sql = a.last[:sql].to_s
+      count += 1 if pattern.match?(sql) && !sql.start_with?("PRAGMA", "BEGIN", "COMMIT")
+    end
+    yield
+    count
+  ensure
+    ActiveSupport::Notifications.unsubscribe(sub)
+  end
+
+  # Simulate a replay pass of an already-finished workflow: reset it to idle and
+  # drop the terminal completion log (and optionally the merge logs, to force the
+  # merge to re-probe instead of short-circuiting on its completed log), then
+  # re-run perform. The branch$ logs stay SEALED, so the branch blocks skip.
+  def replay_pass!(key, drop_merge_logs: false)
+    wf = ChronoForge::Workflow.find_by(key: key)
+    wf.execution_logs.where(step_name: "$workflow_completion$").delete_all
+    wf.execution_logs.where("step_name LIKE 'merge$%'").delete_all if drop_merge_logs
+    wf.update_columns(state: ChronoForge::Workflow.states[:idle], locked_at: nil, locked_by: nil)
+    ReplayBranchWorkflow.perform_later(key)
+    perform_all_jobs
+  end
+end

--- a/test/branch_scale_test.rb
+++ b/test/branch_scale_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class BranchScaleTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    User.delete_all
+    25.times { |i| User.create!(name: "u#{i}", email: "u#{i}@e.com") }
+  end
+
+  def test_dispatch_uses_bulk_inserts_not_one_per_child
+    inserts = 0
+    pattern = /INSERT INTO ["`]?chrono_forge_workflows/i
+    sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*a|
+      inserts += 1 if pattern.match?(a.last[:sql].to_s)
+    end
+    # of: 10 over 25 users => ceil(25/10) = 3 insert_all statements for children.
+    SpawnEachWorkflow.perform_later("scale-1", of: 10)
+    perform_all_jobs
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    branch_log = ChronoForge::Workflow.find_by(key: "scale-1").execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id)
+    assert_equal 25, children.count, "all 25 children dispatched"
+
+    # Expected inserts: 1 (parent row) + 3 (child batches via insert_all) = 4.
+    # Child runs do NOT insert new rows (setup_workflow! finds the pre-inserted row
+    # via find_by). Bound at 8 to allow minor framework overhead while being
+    # meaningfully below 25 (which would indicate non-bulk per-child inserts).
+    assert_operator inserts, :<=, 8,
+      "expected bulk child inserts (~ceil(25/10)=3 plus parent row = ~4 total), got #{inserts}"
+  end
+end

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -53,4 +53,44 @@ class BranchTest < ActiveJob::TestCase
     assert_equal 0, inserts, "sealed branch must not re-dispatch children on replay"
     assert_equal 1, ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).count
   end
+
+  # branch blocks may not be lexically nested within one workflow — spawns belong
+  # to exactly one branch. The guard runs before the block is yielded. (Unit test:
+  # the executor's generic rescue would otherwise swallow the ArgumentError.)
+  def test_lexically_nested_branch_raises
+    job = SingleSpawnWorkflow.new
+    job.instance_variable_set(:@current_branch, {name: "outer", log: nil})
+    error = assert_raises(ArgumentError) do
+      job.branch(:inner) { spawn :x, NoopChild }
+    end
+    assert_match(/nested/, error.message)
+  end
+
+  def test_branch_name_with_dollar_raises
+    workflow = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:"a$b") { spawn :one, NoopChild }
+      end
+    end
+    Object.const_set(:DollarBranchWorkflow, workflow)
+    DollarBranchWorkflow.perform_later("db-1")
+    assert_raises(ChronoForge::Executor::InvalidStepName) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :DollarBranchWorkflow) if defined?(DollarBranchWorkflow)
+  end
+
+  def test_spawn_name_with_dollar_raises
+    workflow = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:ok) { spawn :"a$b", NoopChild }
+      end
+    end
+    Object.const_set(:DollarSpawnWorkflow, workflow)
+    DollarSpawnWorkflow.perform_later("ds-1")
+    assert_raises(ChronoForge::Executor::InvalidStepName) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :DollarSpawnWorkflow) if defined?(DollarSpawnWorkflow)
+  end
 end

--- a/test/branch_test.rb
+++ b/test/branch_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class BranchTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+  def test_spawn_creates_linked_child_and_seals_branch
+    SingleSpawnWorkflow.perform_later("ss-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "ss-1")
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    assert branch_log.completed?, "branch should seal when the block closes"
+
+    child = ChronoForge::Workflow.find_by(key: "ss-1$grp$child")
+    assert child, "child should be created with deterministic key"
+    assert_equal "NoopChild", child.job_class
+    assert_equal branch_log.id, child.parent_execution_log_id
+    assert_equal({"foo" => "bar"}, child.kwargs)
+  end
+
+  def test_spawn_outside_branch_raises
+    workflow = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform = spawn(:x, NoopChild)
+    end
+    Object.const_set(:BareSpawnWorkflow, workflow)
+    BareSpawnWorkflow.perform_later("bare-1")
+    assert_raises(ChronoForge::Executor::NotInBranchError) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :BareSpawnWorkflow) if defined?(BareSpawnWorkflow)
+  end
+
+  def test_sealed_branch_block_is_not_re_executed_on_replay
+    SingleSpawnWorkflow.perform_later("ss-2")
+    perform_all_jobs
+    wf = ChronoForge::Workflow.find_by(key: "ss-2")
+    branch_log = wf.execution_logs.find_by(step_name: "branch$grp")
+
+    # Simulate a mid-execution replay: reset the workflow back to idle so the
+    # executor will accept it again, and remove the completion log so the
+    # engine re-runs the perform body. The branch$grp log is already completed,
+    # so the branch block must be skipped entirely (no new child INSERT).
+    wf.execution_logs.find_by(step_name: "$workflow_completion$")&.destroy
+    wf.update_columns(state: ChronoForge::Workflow.states[:idle])
+
+    inserts = 0
+    sub = ActiveSupport::Notifications.subscribe("sql.active_record") do |*a|
+      inserts += 1 if /INSERT INTO ["`]?chrono_forge_workflows/i.match?(a.last[:sql].to_s)
+    end
+    SingleSpawnWorkflow.perform_later("ss-2")
+    perform_all_jobs
+    ActiveSupport::Notifications.unsubscribe(sub)
+
+    assert_equal 0, inserts, "sealed branch must not re-dispatch children on replay"
+    assert_equal 1, ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).count
+  end
+end

--- a/test/cleanup_test.rb
+++ b/test/cleanup_test.rb
@@ -207,4 +207,36 @@ class CleanupTest < ActiveJob::TestCase
 
     assert exists?(rep), "repetition scheduled within the window must be kept regardless of its created_at"
   end
+
+  # Fix 2: cleanup must nullify parent_execution_log_id on child workflows whose
+  # parent's branch$ log is bulk-deleted (bypassing dependent: :nullify callback).
+  def test_cleanup_nullifies_child_parent_execution_log_id
+    # Parent workflow that is old enough to be reclaimed.
+    parent = make_workflow(state: :completed, terminal_age: 40.days)
+    # A branch$ execution log on the parent.
+    branch_log = ChronoForge::ExecutionLog.create!(
+      workflow: parent,
+      step_name: "branch$cleanup_test",
+      state: :completed
+    )
+    # A child workflow referencing that branch log.
+    child = ChronoForge::Workflow.create!(
+      key: "cleanup_child_#{SecureRandom.hex(4)}",
+      job_class: "NoopChild",
+      kwargs: {}, options: {}, context: {},
+      state: :completed,
+      parent_execution_log_id: branch_log.id
+    )
+
+    Cleanup.run(older_than: 30.days)
+
+    # Parent and its logs are deleted.
+    refute ChronoForge::Workflow.exists?(parent.id), "parent should be reclaimed"
+    refute ChronoForge::ExecutionLog.exists?(branch_log.id), "branch log should be deleted"
+
+    # Child must have its parent_execution_log_id nullified, not left dangling.
+    child.reload
+    assert_nil child.parent_execution_log_id,
+      "child's parent_execution_log_id must be nullified when parent is bulk-deleted"
+  end
 end

--- a/test/generators_test.rb
+++ b/test/generators_test.rb
@@ -31,6 +31,7 @@ class GeneratorsTest < ActiveJob::TestCase
       assert_equal(
         [
           "add_chrono_forge_error_log_step_context.rb",
+          "add_chrono_forge_parent_execution_log.rb",
           "add_chrono_forge_workflow_state_index.rb",
           "install_chrono_forge.rb"
         ],
@@ -46,7 +47,7 @@ class GeneratorsTest < ActiveJob::TestCase
       run_generator(ChronoForge::InstallGenerator, dir)
 
       # Re-running must not duplicate migrations.
-      assert_equal 3, Dir.glob(File.join(dir, "db", "migrate", "*.rb")).size,
+      assert_equal 4, Dir.glob(File.join(dir, "db", "migrate", "*.rb")).size,
         "re-running install must not create duplicate migrations"
     end
   end

--- a/test/internal/app/jobs/enum_spawn_workflow.rb
+++ b/test/internal/app/jobs/enum_spawn_workflow.rb
@@ -1,0 +1,11 @@
+class EnumSpawnWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(items:, of: 1000)
+    branch :grp, automerge: true do
+      spawn_each :things, items, of: of do |item|
+        [NoopChild, {value: item}]
+      end
+    end
+  end
+end

--- a/test/internal/app/jobs/nesting_child.rb
+++ b/test/internal/app/jobs/nesting_child.rb
@@ -1,0 +1,9 @@
+class NestingChild < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(**)
+    branch :sub, automerge: true do
+      spawn :gc, NoopChild
+    end
+  end
+end

--- a/test/internal/app/jobs/nesting_parent_workflow.rb
+++ b/test/internal/app/jobs/nesting_parent_workflow.rb
@@ -1,0 +1,9 @@
+class NestingParentWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :top, automerge: true do
+      spawn :c, NestingChild
+    end
+  end
+end

--- a/test/internal/app/jobs/noop_child.rb
+++ b/test/internal/app/jobs/noop_child.rb
@@ -1,0 +1,11 @@
+class NoopChild < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(**)
+    durably_execute :noop
+  end
+
+  private
+
+  def noop = nil
+end

--- a/test/internal/app/jobs/replay_branch_workflow.rb
+++ b/test/internal/app/jobs/replay_branch_workflow.rb
@@ -1,0 +1,18 @@
+class ReplayBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :items, automerge: true do
+      spawn_each :item, User.all do |u|
+        [NoopChild, {user_id: u.id}]
+      end
+    end
+    durably_execute :finalize
+  end
+
+  private
+
+  def finalize
+    context["finalized"] = true
+  end
+end

--- a/test/internal/app/jobs/single_spawn_workflow.rb
+++ b/test/internal/app/jobs/single_spawn_workflow.rb
@@ -1,0 +1,9 @@
+class SingleSpawnWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :grp, automerge: true do
+      spawn :child, NoopChild, foo: "bar"
+    end
+  end
+end

--- a/test/internal/app/jobs/spawn_each_workflow.rb
+++ b/test/internal/app/jobs/spawn_each_workflow.rb
@@ -1,0 +1,11 @@
+class SpawnEachWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform(of: 1000)
+    branch :grp, automerge: true do
+      spawn_each :items, User.all, of: of do |user|
+        [NoopChild, {user_id: user.id}]
+      end
+    end
+  end
+end

--- a/test/internal/app/jobs/two_branch_workflow.rb
+++ b/test/internal/app/jobs/two_branch_workflow.rb
@@ -1,0 +1,20 @@
+class TwoBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :a do
+      spawn :one, NoopChild
+    end
+    branch :b do
+      spawn :two, NoopChild
+    end
+    merge_branches :a, :b
+    durably_execute :finalize
+  end
+
+  private
+
+  def finalize
+    context["finalized"] = true
+  end
+end

--- a/test/internal/app/jobs/unmerged_branch_workflow.rb
+++ b/test/internal/app/jobs/unmerged_branch_workflow.rb
@@ -1,0 +1,9 @@
+class UnmergedBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :forgotten do   # no automerge, never merged
+      spawn :c, NoopChild
+    end
+  end
+end

--- a/test/internal/config/database.yml
+++ b/test/internal/config/database.yml
@@ -1,3 +1,11 @@
 test:
-  adapter:  sqlite3
+  adapter: <%= ENV.fetch("DB_ADAPTER", "sqlite3") %>
+<% if ENV["DB_ADAPTER"] == "postgresql" %>
+  database: <%= ENV.fetch("DB_DATABASE", "chrono_forge_test") %>
+  host: <%= ENV.fetch("DB_HOST", "localhost") %>
+  port: <%= ENV.fetch("DB_PORT", "5432") %>
+  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "postgres") %>
+<% else %>
   database: db/combustion_test.sqlite
+<% end %>

--- a/test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb
+++ b/test/internal/db/migrate/20260626000001_add_chrono_forge_parent_execution_log.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+require_relative "../../../../lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log"

--- a/test/merge_branches_test.rb
+++ b/test/merge_branches_test.rb
@@ -129,6 +129,37 @@ class MergeBranchesTest < ActiveJob::TestCase
     assert tokens.all?(&:present?), "each branch log carries a fencing token"
     assert_equal 1, tokens.uniq.size, "all branches in the merge share one token"
   end
+
+  # merge_branch (singular) is an alias of merge_branches and must join a branch.
+  def test_merge_branch_singular_alias_joins
+    wf = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:a) { spawn :one, NoopChild }
+        merge_branch :a
+        context["done"] = true
+      end
+    end
+    Object.const_set(:SingularMergeWorkflow, wf)
+    SingularMergeWorkflow.perform_later("singular-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "singular-1")
+    assert parent.completed?, "merge_branch alias should drive the join to completion"
+    assert_equal true, parent.context["done"]
+    assert parent.execution_logs.find_by(step_name: "merge$a")&.completed?
+  ensure
+    Object.send(:remove_const, :SingularMergeWorkflow) if defined?(SingularMergeWorkflow)
+  end
+
+  # A min_interval > max_interval is rejected at the call site (in the parent), not
+  # deep in the poller where the clamp would raise and dead-letter BranchMergeJob.
+  def test_merge_branches_rejects_min_interval_greater_than_max
+    job = SingleSpawnWorkflow.new
+    assert_raises(ArgumentError) do
+      job.merge_branches(:a, min_interval: 10.seconds, max_interval: 5.seconds)
+    end
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/test/merge_branches_test.rb
+++ b/test/merge_branches_test.rb
@@ -30,6 +30,36 @@ class MergeBranchesTest < ActiveJob::TestCase
     Object.send(:remove_const, :NoBranchMergeWorkflow) if defined?(NoBranchMergeWorkflow)
   end
 
+  def test_merge_branches_rejects_dollar_name
+    bad_dollar = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:a) { spawn :one, NoopChild }
+        merge_branches :"a$b"
+      end
+    end
+    Object.const_set(:DollarMergeWorkflow, bad_dollar)
+    DollarMergeWorkflow.perform_later("dm-1")
+    assert_raises(ChronoForge::Executor::InvalidStepName) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :DollarMergeWorkflow) if defined?(DollarMergeWorkflow)
+  end
+
+  def test_merge_branches_rejects_comma_name
+    bad_comma = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:a) { spawn :one, NoopChild }
+        merge_branches :"a,b"
+      end
+    end
+    Object.const_set(:CommaMergeWorkflow, bad_comma)
+    CommaMergeWorkflow.perform_later("cm-1")
+    assert_raises(ChronoForge::Executor::InvalidStepName) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :CommaMergeWorkflow) if defined?(CommaMergeWorkflow)
+  end
+
   def test_incomplete_child_keeps_parent_parked
     # StalledBranchWorkflow has branch :a (stalling child) and branch :b (noop).
     # The stalling child raises on every attempt and exhausts retries → failed.

--- a/test/merge_branches_test.rb
+++ b/test/merge_branches_test.rb
@@ -25,7 +25,7 @@ class MergeBranchesTest < ActiveJob::TestCase
     end
     Object.const_set(:NoBranchMergeWorkflow, job)
     NoBranchMergeWorkflow.perform_later("nb-1")
-    assert_raises(ArgumentError) { perform_all_jobs }
+    assert_raises(ChronoForge::Executor::UnknownBranchError) { perform_all_jobs }
   ensure
     Object.send(:remove_const, :NoBranchMergeWorkflow) if defined?(NoBranchMergeWorkflow)
   end

--- a/test/merge_branches_test.rb
+++ b/test/merge_branches_test.rb
@@ -60,6 +60,30 @@ class MergeBranchesTest < ActiveJob::TestCase
     Object.send(:remove_const, :CommaMergeWorkflow) if defined?(CommaMergeWorkflow)
   end
 
+  def test_duplicate_names_treated_as_single_branch
+    # merge_branches :a, :a must dedup to :a and behave identically to merge_branches :a.
+    dup_wf = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:a) { spawn :one, NoopChild }
+        merge_branches :a, :a
+        context["done"] = true
+      end
+    end
+    Object.const_set(:DupMergeWorkflow, dup_wf)
+    DupMergeWorkflow.perform_later("dup-merge-1")
+    perform_all_jobs
+
+    wf = ChronoForge::Workflow.find_by(key: "dup-merge-1")
+    assert wf.completed?, "parent should complete with deduped branch names"
+    assert_equal true, wf.context["done"]
+    merge_log = wf.execution_logs.find { |l| l.step_name == "merge$a" }
+    assert merge_log, "merge log should be named merge$a (single, deduped)"
+    assert merge_log.completed?
+  ensure
+    Object.send(:remove_const, :DupMergeWorkflow) if defined?(DupMergeWorkflow)
+  end
+
   def test_incomplete_child_keeps_parent_parked
     # StalledBranchWorkflow has branch :a (stalling child) and branch :b (noop).
     # The stalling child raises on every attempt and exhausts retries → failed.

--- a/test/merge_branches_test.rb
+++ b/test/merge_branches_test.rb
@@ -113,6 +113,22 @@ class MergeBranchesTest < ActiveJob::TestCase
     assert bad_child, "stalling child workflow should exist"
     assert bad_child.failed?, "stalling child should be in failed state"
   end
+
+  def test_merge_stamps_shared_fencing_token_on_branch_logs
+    TwoBranchWorkflow.perform_later("mb-token")
+    # Run only the parent's first pass: it dispatches children and halts at the
+    # merge after stamping the fencing token on the branch logs. The children and
+    # the poller stay queued (filtered out), so we observe the post-stamp state.
+    perform_enqueued_jobs(only: TwoBranchWorkflow)
+
+    parent = ChronoForge::Workflow.find_by(key: "mb-token")
+    tokens = parent.execution_logs
+      .where("step_name LIKE 'branch$%'")
+      .map { |l| l.metadata["poll_token"] }
+    assert_equal 2, tokens.size, "both branch logs present"
+    assert tokens.all?(&:present?), "each branch log carries a fencing token"
+    assert_equal 1, tokens.uniq.size, "all branches in the merge share one token"
+  end
 end
 
 # ---------------------------------------------------------------------------

--- a/test/merge_branches_test.rb
+++ b/test/merge_branches_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class MergeBranchesTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    ChronoForge::Workflow.destroy_all
+  end
+
+  def test_parent_resumes_after_branches_complete
+    TwoBranchWorkflow.perform_later("mb-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "mb-1")
+    assert parent.completed?, "parent should complete once both branches merge"
+    assert_equal true, parent.context["finalized"]
+    merge_log = parent.execution_logs.find { |l| l.step_name.start_with?("merge$") }
+    assert merge_log.completed?
+  end
+
+  def test_unopened_branch_name_raises
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform = merge_branches(:nope)
+    end
+    Object.const_set(:NoBranchMergeWorkflow, job)
+    NoBranchMergeWorkflow.perform_later("nb-1")
+    assert_raises(ArgumentError) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :NoBranchMergeWorkflow) if defined?(NoBranchMergeWorkflow)
+  end
+
+  def test_incomplete_child_keeps_parent_parked
+    # StalledBranchWorkflow has branch :a (stalling child) and branch :b (noop).
+    # The stalling child raises on every attempt and exhausts retries → failed.
+    # BranchMergeJob counts failed children as "pending" (Option A: only
+    # :completed is done), so the parent stays parked. We bound the time window
+    # so perform_all_jobs_before stops after the BMJ has rescheduled once (5s
+    # wait), giving us a deterministic assertion without hanging.
+    StalledBranchWorkflow.perform_later("sb-1")
+
+    # Run enough to: (a) execute parent, (b) run both children, (c) run the
+    # first BranchMergeJob poll (enqueued immediately with no wait). The BMJ
+    # finds a failed (non-:completed) child and reschedules itself with a 5s
+    # wait — which is beyond 4s, so the loop terminates.
+    perform_all_jobs_before(4.seconds)
+
+    parent = ChronoForge::Workflow.find_by(key: "sb-1")
+    refute parent.completed?, "parent should NOT be completed while a child is failed"
+    assert_nil parent.context["finalized"], "finalize step must not run while merge is parked"
+
+    merge_log = parent.execution_logs.find { |l| l.step_name.start_with?("merge$") }
+    refute merge_log&.completed?, "merge log must not be completed while a child is failed"
+
+    # Confirm the stalling child really did fail (not stalled, which would be a
+    # different workflow-level failure mode).
+    child_key = "sb-1$a$bad"
+    bad_child = ChronoForge::Workflow.find_by(key: child_key)
+    assert bad_child, "stalling child workflow should exist"
+    assert bad_child.failed?, "stalling child should be in failed state"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+# A child that always raises → exhausts workflow-level retries → ends up failed.
+# max_attempts: 1 means exactly one attempt, no retry jobs → terminates fast.
+class StallingChild < WorkflowJob
+  prepend ChronoForge::Executor
+  retry_policy max_attempts: 1
+
+  def perform(**)
+    raise "stalling child always fails"
+  end
+end
+
+class StalledBranchWorkflow < WorkflowJob
+  prepend ChronoForge::Executor
+
+  def perform
+    branch :a do
+      spawn :bad, StallingChild
+    end
+    branch :b do
+      spawn :good, NoopChild
+    end
+    merge_branches :a, :b
+    durably_execute :finalize
+  end
+
+  private
+
+  def finalize
+    context["finalized"] = true
+  end
+end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -10,4 +10,14 @@ class SchemaTest < ActiveJob::TestCase
       "expected a composite index on chrono_forge_workflows [state, completed_at] " \
       "to support monitoring and the completed-workflow retention cleanup scan"
   end
+
+  def test_workflows_have_parent_execution_log_id_column
+    assert connection.column_exists?(:chrono_forge_workflows, :parent_execution_log_id),
+      "expected chrono_forge_workflows.parent_execution_log_id for branch children"
+  end
+
+  def test_workflows_have_parent_execution_log_state_index
+    assert connection.index_exists?(:chrono_forge_workflows, %i[parent_execution_log_id state]),
+      "expected composite index on [parent_execution_log_id, state] for the merge probe"
+  end
 end

--- a/test/spawn_each_test.rb
+++ b/test/spawn_each_test.rb
@@ -16,11 +16,10 @@ class SpawnEachTest < ActiveJob::TestCase
     branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
     children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).order(:key)
 
+    assert_equal @users.map { |u| "se-1$grp$items_#{u.id}" }.sort, children.pluck(:key).sort
     assert_equal 5, children.count
-    assert_equal (0..4).map { |i| "se-1$grp$items_#{i}" }, children.pluck(:key)
-    assert_equal @users.first.id, children.first.kwargs["user_id"]
     cursor = branch_log.reload.metadata["cursors"]["items"]
-    assert_equal 5, cursor["n"]
+    assert_equal @users.last.id, cursor["pk"]
   end
 
   def test_spawn_each_honors_class_from_block

--- a/test/spawn_each_test.rb
+++ b/test/spawn_each_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class SpawnEachTest < ActiveJob::TestCase
+  include ChaoticJob::Helpers
+
+  def setup
+    User.delete_all
+    @users = 5.times.map { |i| User.create!(name: "u#{i}", email: "u#{i}@e.com") }
+  end
+
+  def test_spawn_each_creates_one_indexed_child_per_item
+    SpawnEachWorkflow.perform_later("se-1")
+    perform_all_jobs
+
+    parent = ChronoForge::Workflow.find_by(key: "se-1")
+    branch_log = parent.execution_logs.find_by(step_name: "branch$grp")
+    children = ChronoForge::Workflow.where(parent_execution_log_id: branch_log.id).order(:key)
+
+    assert_equal 5, children.count
+    assert_equal (0..4).map { |i| "se-1$grp$items_#{i}" }, children.pluck(:key)
+    assert_equal @users.first.id, children.first.kwargs["user_id"]
+    cursor = branch_log.reload.metadata["cursors"]["items"]
+    assert_equal 5, cursor["n"]
+  end
+
+  def test_spawn_each_honors_class_from_block
+    klass = Class.new(WorkflowJob) { prepend ChronoForge::Executor; def perform(**) = nil }
+    Object.const_set(:AltChild, klass)
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:g, automerge: true) do
+          spawn_each(:i, User.all) { |u| u.id.even? ? [AltChild, {id: u.id}] : [NoopChild, {id: u.id}] }
+        end
+      end
+    end
+    Object.const_set(:MixedClassWorkflow, job)
+
+    MixedClassWorkflow.perform_later("mc-1")
+    perform_all_jobs
+
+    classes = ChronoForge::Workflow.where("key LIKE ?", "mc-1$g$i_%").pluck(:job_class).uniq.sort
+    assert_equal %w[AltChild NoopChild], classes
+  ensure
+    Object.send(:remove_const, :AltChild) if defined?(AltChild)
+    Object.send(:remove_const, :MixedClassWorkflow) if defined?(MixedClassWorkflow)
+  end
+
+  def test_spawn_each_raises_on_conflicting_order
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:g, automerge: true) do
+          spawn_each(:i, User.order(:email)) { |u| [NoopChild, {id: u.id}] }
+        end
+      end
+    end
+    Object.const_set(:BadOrderWorkflow, job)
+    BadOrderWorkflow.perform_later("bo-1")
+    assert_raises(ChronoForge::Executor::NotExecutableError) { perform_all_jobs }
+  ensure
+    Object.send(:remove_const, :BadOrderWorkflow) if defined?(BadOrderWorkflow)
+  end
+
+  def test_spawn_each_over_plain_enumerable
+    job = Class.new(WorkflowJob) do
+      prepend ChronoForge::Executor
+      def perform
+        branch(:g, automerge: true) do
+          spawn_each(:n, [10, 20, 30]) { |val| [NoopChild, {val: val}] }
+        end
+      end
+    end
+    Object.const_set(:EnumWorkflow, job)
+    EnumWorkflow.perform_later("en-1")
+    perform_all_jobs
+
+    keys = ChronoForge::Workflow.where("key LIKE ?", "en-1$g$n_%").order(:key).pluck(:key)
+    assert_equal %w[en-1$g$n_0 en-1$g$n_1 en-1$g$n_2], keys
+  ensure
+    Object.send(:remove_const, :EnumWorkflow) if defined?(EnumWorkflow)
+  end
+end

--- a/test/spawn_each_test.rb
+++ b/test/spawn_each_test.rb
@@ -23,7 +23,10 @@ class SpawnEachTest < ActiveJob::TestCase
   end
 
   def test_spawn_each_honors_class_from_block
-    klass = Class.new(WorkflowJob) { prepend ChronoForge::Executor; def perform(**) = nil }
+    klass = Class.new(WorkflowJob) {
+      prepend ChronoForge::Executor
+      def perform(**) = nil
+    }
     Object.const_set(:AltChild, klass)
     job = Class.new(WorkflowJob) do
       prepend ChronoForge::Executor

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,17 @@ require "minitest/reporters"
 Minitest::Reporters.use!
 
 require "combustion"
+
+# Activate strong_migrations before Combustion runs the gem's migrations, so an
+# unsafe migration template (non-concurrent index, blocking column rewrite, etc.)
+# raises StrongMigrations::UnsafeMigration during boot rather than shipping to
+# users. strong_migrations only supports PostgreSQL/MySQL — on the default SQLite
+# test DB it is a no-op (and noisy), so it is skipped there. The Postgres CI lane
+# (DB_ADAPTER=postgresql) runs every gem migration under strong_migrations for
+# real, failing the build on any unsafe migration.
+require "strong_migrations"
+StrongMigrations.skip_database(:primary) unless ENV["DB_ADAPTER"] == "postgresql"
+
 Combustion.path = "test/internal"
 Combustion.initialize! :active_record, :active_job
 

--- a/test/upgrade_migration_test.rb
+++ b/test/upgrade_migration_test.rb
@@ -3,6 +3,10 @@ require File.expand_path(
   "../lib/generators/chrono_forge/templates/add_chrono_forge_workflow_state_index.rb",
   __dir__
 )
+require File.expand_path(
+  "../lib/generators/chrono_forge/templates/add_chrono_forge_parent_execution_log.rb",
+  __dir__
+)
 
 # Exercises the upgrade migration shipped for existing installations (which
 # already ran the original install migration and therefore need a separate,
@@ -37,5 +41,38 @@ class UpgradeMigrationTest < ActiveJob::TestCase
   ensure
     # Restore schema for the rest of the suite regardless of outcome.
     connection.add_index(:chrono_forge_workflows, %i[state completed_at]) unless index_present?
+  end
+
+  def parent_log_column_present?
+    connection.column_exists?(:chrono_forge_workflows, :parent_execution_log_id)
+  end
+
+  def parent_log_index_present?
+    connection.index_exists?(:chrono_forge_workflows, %i[parent_execution_log_id state])
+  end
+
+  def test_migration_adds_parent_execution_log_and_is_idempotent
+    # Simulate an existing install that predates the parent_execution_log_id
+    # column/index.
+    connection.remove_index(:chrono_forge_workflows, %i[parent_execution_log_id state]) if parent_log_index_present?
+    connection.remove_column(:chrono_forge_workflows, :parent_execution_log_id) if parent_log_column_present?
+    refute parent_log_column_present?, "precondition: column removed"
+    refute parent_log_index_present?, "precondition: index removed"
+
+    silence_migration { AddChronoForgeParentExecutionLog.new.migrate(:up) }
+    assert parent_log_column_present?, "migration should add the parent_execution_log_id column"
+    assert parent_log_index_present?, "migration should add the [parent_execution_log_id, state] index"
+
+    # Running it again must not raise (if_not_exists guards) — operators may
+    # re-run migrations.
+    assert_nothing_raised do
+      silence_migration { AddChronoForgeParentExecutionLog.new.migrate(:up) }
+    end
+    assert parent_log_column_present?
+    assert parent_log_index_present?
+  ensure
+    # Restore schema for the rest of the suite regardless of outcome.
+    connection.add_column(:chrono_forge_workflows, :parent_execution_log_id, :bigint, null: true) unless parent_log_column_present?
+    connection.add_index(:chrono_forge_workflows, %i[parent_execution_log_id state]) unless parent_log_index_present?
   end
 end


### PR DESCRIPTION
## Summary

Adds a durable fan-out/fan-in primitive to ChronoForge, built to dispatch **hundreds of thousands** of child sub-workflows per group.

- **`branch :name [, automerge: true] do … end`** — a durable coordination step. Inside it, spawns eagerly dispatch children (they start running immediately); the branch *seals* when the block closes, and a sealed branch skips its block entirely on replay (the source enumeration never re-runs).
- **`spawn :name, WorkflowClass, **kwargs`** — one child. **`spawn_each :name, source do |item| [WorkflowClass, kwargs] end`** — one child per item, streamed via AR keyset (`find_in_batches`) at constant memory; the class comes from the block (mixed types OK).
- **`merge_branches :a, :b`** (alias `merge_branch`) — the *separate* join: open branches without automerge, let them run concurrently, then join at a chosen point. Polling is delegated to a lightweight `ChronoForge::BranchMergeJob` so the heavy parent isn't replayed per poll; cadence is an adaptive capped-count probe.
- **`automerge: true`** — joins the branch **inline at its block's close** (dispatch + immediate await).
- **Every branch must be joined** (`merge_branches` or `automerge`), else `UnmergedBranchError` at completion — no silently-orphaned children. **Option A** failure semantics: a failed/stalled child keeps the parent parked until recovered.

### Implementation notes
- One new generic column `parent_execution_log_id` on `chrono_forge_workflows` (FK to the spawning execution log) + composite `(parent_execution_log_id, state)` index; shipped as an additive migration wired into the install/upgrade generators.
- Crash-safe & idempotent: deterministic child keys + `insert_all` on-conflict-ignore + per-spawn cursor for resume; only `:idle` children are (re)enqueued so a crash-resume never re-runs a completed child.
- New dependency floor **`activejob >= 7.1`** (for `perform_all_later`).
- Added a PostgreSQL CI lane that runs the gem's migrations under **strong_migrations** (it's a no-op on the SQLite test DB).

## Test Plan
- [x] `bundle exec rake test` green — **177 tests, 706 assertions, 0 failures**
- [x] Per-component tests: branch/spawn, spawn_each (AR + enumerable, mixed classes, order guard), BranchMergeJob poller, merge_branches, automerge + unmerged-raise
- [x] Crash-recovery (ChaoticJob glitch mid-dispatch → cursor resume, no duplicate children) and scale (bulk `insert_all`, `⌈N/of⌉` not N) regression guards
- [x] Integration: empty source/branch, nested branches (bottom-up completion)
- [ ] CI: PostgreSQL `migration-safety` lane runs the migrations under strong_migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)