### PR TITLE
feat(context): bulk merge / merge_once for context

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,6 +656,12 @@ context.set(:total_amount, 99.99)
 # Set a value only if the key doesn't already exist
 context.set_once(:created_at, Time.current.iso8601)
 
+# Set several values at once (alias: set_multiple)
+context.merge(status: "processing", total_amount: 99.99, attempts: 0)
+
+# Set several values at once, but only keys that don't already exist (alias: set_multiple_once)
+context.merge_once(created_at: Time.current.iso8601, attempts: 0)
+
 # Check if a key exists
 if context.key?(:user_id)
   # Do something with the user ID
@@ -1097,6 +1103,8 @@ Fan a workflow out into parallel child sub-workflows (see [Branches](#-branches-
 | `context[:key]` | Get context value | `user_id = context[:user_id]` |
 | `context.set(key, value)` | Set context value (alias) | `context.set(:status, "active")` |
 | `context.set_once(key, value)` | Set only if key doesn't exist | `context.set_once(:created_at, Time.current)` |
+| `context.merge(hash)` | Set multiple values atomically (alias: `set_multiple`) | `context.merge(status: "active", count: 0)` |
+| `context.merge_once(hash)` | Set multiple values, skipping existing keys (alias: `set_multiple_once`) | `context.merge_once(created_at: Time.current, count: 0)` |
 | `context.fetch(key, default)` | Get with default value | `context.fetch(:count, 0)` |
 | `context.key?(key)` | Check if key exists | `context.key?(:user_id)` |
 

--- a/lib/chrono_forge/executor/context.rb
+++ b/lib/chrono_forge/executor/context.rb
@@ -51,6 +51,29 @@ module ChronoForge
         set_value(key, value)
       end
 
+      # Sets multiple values in the context at once from a hash.
+      # The merge is atomic: every value is validated before any is written, so
+      # a single invalid value raises and leaves the context untouched.
+      # Returns self for chaining.
+      def merge(hash)
+        hash.each_value { |value| validate_value!(value) }
+        hash.each { |key, value| set_value(key, value) }
+        self
+      end
+      alias_method :set_multiple, :merge
+
+      # Like #merge, but only sets keys that don't already exist; present keys
+      # are skipped entirely (their values are never validated), matching
+      # #set_once semantics. The applied keys are written atomically: an invalid
+      # value among the new keys raises and writes nothing. Returns self.
+      def merge_once(hash)
+        new_pairs = hash.reject { |key, _| key?(key) }
+        new_pairs.each_value { |value| validate_value!(value) }
+        new_pairs.each { |key, value| set_value(key, value) }
+        self
+      end
+      alias_method :set_multiple_once, :merge_once
+
       # Sets a value in the context only if the key doesn't already exist
       # Returns true if the value was set, false otherwise
       def set_once(key, value)

--- a/test/context_test.rb
+++ b/test/context_test.rb
@@ -66,6 +66,110 @@ class ContextTest < ActiveJob::TestCase
     assert_equal({"a" => [1, 2, 3]}, context[:ok_hash])
   end
 
+  def test_merge_sets_multiple_keys_at_once
+    context = build_context
+
+    context.merge(status: "active", total: 99.99, count: 3)
+
+    assert_equal "active", context[:status]
+    assert_equal 99.99, context[:total]
+    assert_equal 3, context[:count]
+  end
+
+  def test_merge_normalizes_symbol_keys_and_stores_deep_copies
+    context = build_context
+    source = {"items" => [1, 2, 3]}
+
+    context.merge(payload: source, flag: true)
+    source["items"] << 4
+
+    assert_equal({"items" => [1, 2, 3]}, context[:payload],
+      "merged values must be deep copies, immune to later mutation of the source")
+    assert_equal true, context[:flag]
+  end
+
+  def test_merge_is_atomic_when_a_value_is_invalid
+    context = build_context
+    context[:existing] = "keep"
+
+    assert_raises(Context::ValidationError) do
+      context.merge(ok: "fine", big: "x" * (Context::MAX_VALUE_BYTESIZE + 1))
+    end
+
+    assert_equal "keep", context[:existing]
+    refute context.key?(:ok),
+      "no key should be written when any value in the merge is invalid"
+  end
+
+  def test_set_multiple_is_an_alias_for_merge
+    context = build_context
+
+    context.set_multiple(a: 1, b: 2)
+
+    assert_equal 1, context[:a]
+    assert_equal 2, context[:b]
+  end
+
+  def test_merge_returns_self_for_chaining
+    context = build_context
+
+    assert_same context, context.merge(a: 1)
+  end
+
+  def test_merge_with_empty_hash_is_a_no_op
+    context = build_context
+
+    assert_same context, context.merge({})
+    refute context.key?(:anything)
+  end
+
+  def test_merge_once_sets_only_absent_keys
+    context = build_context
+    context[:status] = "existing"
+
+    context.merge_once(status: "new", count: 5)
+
+    assert_equal "existing", context[:status], "present keys must not be overwritten"
+    assert_equal 5, context[:count], "absent keys should be set"
+  end
+
+  def test_merge_once_skips_present_keys_without_validating_them
+    context = build_context
+    context[:status] = "existing"
+
+    # The oversized value sits under an already-present key, so it is skipped
+    # entirely — never validated — matching set_once semantics.
+    context.merge_once(status: "x" * (Context::MAX_VALUE_BYTESIZE + 1), count: 5)
+
+    assert_equal "existing", context[:status]
+    assert_equal 5, context[:count]
+  end
+
+  def test_merge_once_is_atomic_across_the_new_keys
+    context = build_context
+
+    assert_raises(Context::ValidationError) do
+      context.merge_once(ok: "fine", big: "x" * (Context::MAX_VALUE_BYTESIZE + 1))
+    end
+
+    refute context.key?(:ok), "no new key should be written when any new value is invalid"
+  end
+
+  def test_set_multiple_once_is_an_alias_for_merge_once
+    context = build_context
+
+    context.set_multiple_once(a: 1, b: 2)
+
+    assert_equal 1, context[:a]
+    assert_equal 2, context[:b]
+  end
+
+  def test_merge_once_returns_self_for_chaining
+    context = build_context
+
+    assert_same context, context.merge_once(a: 1)
+  end
+
   def test_preserves_scalar_values
     context = build_context
 


### PR DESCRIPTION
Closes #2.

## What

Adds bulk equivalents of the single-key context setters, so multiple values can be set in one call instead of:

```ruby
updated_context.each { |key, value| context.set(key, value) }
```

| Single | Bulk |
|--------|------|
| `set` / `[]=` | `merge` (alias `set_multiple`) |
| `set_once` | `merge_once` (alias `set_multiple_once`) |

```ruby
context.merge(status: "active", total: 99.99, attempts: 0)
context.merge_once(created_at: Time.current.iso8601, attempts: 0)  # skips keys already present
```

## Behavior

- Each value is validated + normalized exactly like `set`/`set_once` (type check, 16 KB cap, symbol→string keys, deep copy of Hash/Array).
- **Atomic** — every value is validated before any is written, so one invalid value raises `ValidationError` and writes nothing (no half-applied merge).
- `merge_once` skips already-present keys *entirely* — their values are never validated — matching `set_once` semantics.
- Both return `self` for chaining.

## Tests

11 new cases in `test/context_test.rb` covering multi-key set, key normalization + deep copy, atomic rejection, the once/skip semantics, aliases, and `self` return. Full suite (242 tests) green, standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)