### PR TITLE
chore: fix standardrb offenses so the default rake task passes again

### DIFF
--- a/chrono_forge-dashboard/app/queries/chrono_forge/dashboard/repetitions_query.rb
+++ b/chrono_forge-dashboard/app/queries/chrono_forge/dashboard/repetitions_query.rb
@@ -43,6 +43,7 @@ module ChronoForge
       end
 
       def next_cursor = records.last&.id
+
       def prev_cursor = records.first&.id
 
       # Cheap roll-up (counts + last run) without loading run rows. Grouping by

--- a/chrono_forge-dashboard/app/queries/chrono_forge/dashboard/workflows_query.rb
+++ b/chrono_forge-dashboard/app/queries/chrono_forge/dashboard/workflows_query.rb
@@ -46,6 +46,7 @@ module ChronoForge
       end
 
       def next_cursor = records.last&.id
+
       def prev_cursor = records.first&.id
 
       private

--- a/chrono_forge-dashboard/lib/chrono_forge/dashboard.rb
+++ b/chrono_forge-dashboard/lib/chrono_forge/dashboard.rb
@@ -10,7 +10,9 @@ module ChronoForge
 
     class << self
       def config = (@config ||= Configuration.new)
+
       def configure = yield(config)
+
       def reset_configuration! = @config = Configuration.new
 
       # Short content digest of a shipped asset, used to cache-bust the served

--- a/chrono_forge-dashboard/test/dashboard_helper_test.rb
+++ b/chrono_forge-dashboard/test/dashboard_helper_test.rb
@@ -149,9 +149,13 @@ class DashboardHelperTest < ActionView::TestCase
   # Minimal stand-in for a Workflow row — only the fields the helper reads.
   WorkflowStub = Struct.new(:state, :started_at, :ended_at) do
     def completed_at = (state == :completed) ? ended_at : nil
+
     def updated_at = ended_at
+
     def running? = state == :running
+
     def failed? = state == :failed
+
     def stalled? = state == :stalled
   end
 end

--- a/lib/chrono_forge/branch_merge_job.rb
+++ b/lib/chrono_forge/branch_merge_job.rb
@@ -123,7 +123,8 @@ module ChronoForge
       motion = if rate > 0 then nil
       elsif branch_log_ids.any? { |id| BranchProbe.running?(id) } then :running
       elsif never_started_by_branch.values.any?(&:positive?) then :never_started
-      else :none
+      else
+        :none
       end
 
       delay = reschedule_delay(pending, rate, motion, prev_delay, min_interval, max_interval)
@@ -206,8 +207,8 @@ module ChronoForge
             "spawned" => prev["spawned"] || spawned_by_branch[log.id],  # total spawned; immutable once sealed, so sticky
             "sealed" => sealed_by_branch[log.id],
             "rate" => rate.round(3),                               # children/s (round(3), not (2), so a
-                                                                   # very slow but real drain still reads > 0)
-            "eta_seconds" => (rate > 0 ? (pend / rate).round : nil),
+            # very slow but real drain still reads > 0)
+            "eta_seconds" => ((rate > 0) ? (pend / rate).round : nil),
             "polls" => prev["polls"].to_i + 1,
             "rekicked" => n,
             "rekick_total" => prev["rekick_total"].to_i + n,

--- a/test/branch_merge_job_test.rb
+++ b/test/branch_merge_job_test.rb
@@ -388,7 +388,7 @@ class BranchMergeJobTest < ActiveJob::TestCase
   # still rekicked because the never-started count did not fall.
   def test_rekicks_dropped_child_when_only_waits_drain_pending
     @log.update!(metadata: {"poll" => {"pending" => 3, "never_started" => 1,
-      "last_polled_at" => 30.seconds.ago.iso8601, "polls" => 2}})
+                                       "last_polled_at" => 30.seconds.ago.iso8601, "polls" => 2}})
     child!(state: :completed)                        # a wait that resumed + completed
     child!(state: :idle, started_at: 20.minutes.ago) # a child still parked on a wait
     dropped = child!(state: :idle, started_at: nil)  # genuinely dropped, never started


### PR DESCRIPTION
## Summary
- `bundle exec rake` (test + standard) was failing on `main` with 12 standardrb offenses in `chrono_forge-dashboard/`, `lib/chrono_forge/branch_merge_job.rb`, and `test/branch_merge_job_test.rb`, making the lint gate meaningless for feature branches.
- All fixes are `standardrb --fix` output: empty lines between defs, else layout, ternary parentheses, hash alignment, comment indentation. No behavior changes.

## Test Plan
- [x] Full suite: 307 tests, 1059 assertions, 0 failures
- [x] `bundle exec standardrb` exits 0 repo-wide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WWxs4QFj8T2SFThSkriYHz